### PR TITLE
Support React 15.5 PropTypes deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,15 @@
     "css-loader": "^0.27.3",
     "less": "^2.7.2",
     "less-loader": "^3.0.0",
+    "prop-types": "^15.5.6",
     "style-loader": "^0.16.1",
     "stylelint": "^7.10.1",
     "stylelint-config-standard": "^16.0.0"
   },
   "jest": {
-    "snapshotSerializers": ["enzyme-to-json/serializer"],
+    "snapshotSerializers": [
+      "enzyme-to-json/serializer"
+    ],
     "moduleNameMapper": {
       "\\.less$": "<rootDir>/scripts/less-mock.js"
     }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "babel-preset-es2015": "^6.24.0",
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-0": "^6.22.0",
-    "enzyme": "^2.8.0",
+    "enzyme": "^2.8.1",
     "enzyme-to-json": "^1.5.0",
     "eslint": "^3.18.0",
     "eslint-config-fyndiq": "0.0.1",
@@ -33,8 +33,8 @@
     "jest": "^19.0.2",
     "lerna": "2.0.0-beta.38",
     "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "react-dom": "^15.4.2",
+    "react-test-renderer": "^15.5.4"
   },
   "dependencies": {
     "css-loader": "^0.27.3",

--- a/packages/fyndiq-component-button/src/index.js
+++ b/packages/fyndiq-component-button/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styles from '../styles.less'
 
 const Button = ({ children, onClick, type, size, horizontal, disabled, pressed }) => (
@@ -19,13 +20,13 @@ const Button = ({ children, onClick, type, size, horizontal, disabled, pressed }
 )
 
 Button.propTypes = {
-  children: React.PropTypes.node.isRequired,
-  onClick: React.PropTypes.func,
-  type: React.PropTypes.string,
-  size: React.PropTypes.string,
-  horizontal: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
-  pressed: React.PropTypes.bool,
+  children: PropTypes.node.isRequired,
+  onClick: PropTypes.func,
+  type: PropTypes.string,
+  size: PropTypes.string,
+  horizontal: PropTypes.bool,
+  disabled: PropTypes.bool,
+  pressed: PropTypes.bool,
 }
 
 Button.defaultProps = {

--- a/packages/fyndiq-component-checkbox/src/index.js
+++ b/packages/fyndiq-component-checkbox/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Checkmark from 'fyndiq-icon-checkmark'
 import colors from 'fyndiq-styles-colors'
 import styles from '../styles.less'
@@ -45,11 +46,11 @@ class Checkbox extends React.Component {
 }
 
 Checkbox.propTypes = {
-  onToggle: React.PropTypes.func,
-  checked: React.PropTypes.bool,
-  disabled: React.PropTypes.bool,
-  color: React.PropTypes.string,
-  className: React.PropTypes.string,
+  onToggle: PropTypes.func,
+  checked: PropTypes.bool,
+  disabled: PropTypes.bool,
+  color: PropTypes.string,
+  className: PropTypes.string,
 }
 
 Checkbox.defaultProps = {

--- a/packages/fyndiq-component-dropdown/src/index.js
+++ b/packages/fyndiq-component-dropdown/src/index.js
@@ -1,19 +1,20 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Button from 'fyndiq-component-button'
 import Arrow from 'fyndiq-icon-arrow'
 import styles from '../styles.less'
 
 class Dropdown extends React.Component {
   static propTypes = {
-    opened: React.PropTypes.bool,
-    button: React.PropTypes.oneOfType([
-      React.PropTypes.string,
-      React.PropTypes.element,
+    opened: PropTypes.bool,
+    button: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.element,
     ]).isRequired,
-    children: React.PropTypes.node.isRequired,
-    size: React.PropTypes.string,
-    noArrow: React.PropTypes.bool,
-    noContentPadding: React.PropTypes.bool,
+    children: PropTypes.node.isRequired,
+    size: PropTypes.string,
+    noArrow: PropTypes.bool,
+    noContentPadding: PropTypes.bool,
   }
 
   static defaultProps = {

--- a/packages/fyndiq-component-productcard/src/index.js
+++ b/packages/fyndiq-component-productcard/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import { Price, CurrentPrice, OldPrice } from 'fyndiq-component-price'
 import Stars from 'fyndiq-component-stars'
 import styles from '../styles.less'
@@ -16,11 +17,11 @@ const Productcard = ({ price, title, url, oldprice, rating }) => (
 )
 
 Productcard.propTypes = {
-  price: React.PropTypes.string.isRequired,
-  title: React.PropTypes.string.isRequired,
-  url: React.PropTypes.string.isRequired,
-  oldprice: React.PropTypes.string,
-  rating: React.PropTypes.number,
+  price: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  url: PropTypes.string.isRequired,
+  oldprice: PropTypes.string,
+  rating: PropTypes.number,
 }
 
 Productcard.defaultProps = {

--- a/packages/fyndiq-component-stars/src/index.js
+++ b/packages/fyndiq-component-stars/src/index.js
@@ -1,14 +1,15 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Star from 'fyndiq-icon-star'
 import styles from '../styles.less'
 
 class Stars extends React.Component {
   static propTypes = {
-    rating: React.PropTypes.number,
-    reviews: React.PropTypes.number,
-    size: React.PropTypes.string,
-    interactive: React.PropTypes.bool,
-    onChange: React.PropTypes.func,
+    rating: PropTypes.number,
+    reviews: PropTypes.number,
+    size: PropTypes.string,
+    interactive: PropTypes.bool,
+    onChange: PropTypes.func,
   }
 
   static defaultProps = {

--- a/packages/fyndiq-icon-arrow/src/index.js
+++ b/packages/fyndiq-icon-arrow/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styles from '../styles.less'
 
 const Arrow = ({ orientation, className }) => {
@@ -31,8 +32,8 @@ const Arrow = ({ orientation, className }) => {
 }
 
 Arrow.propTypes = {
-  orientation: React.PropTypes.oneOf(['up', 'down', 'right', 'left']),
-  className: React.PropTypes.string,
+  orientation: PropTypes.oneOf(['up', 'down', 'right', 'left']),
+  className: PropTypes.string,
 }
 
 Arrow.defaultProps = {

--- a/packages/fyndiq-icon-brand/src/index.js
+++ b/packages/fyndiq-icon-brand/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import styles from '../styles.less'
 
@@ -20,9 +21,9 @@ const FyndiqLogo = ({ className, height, width, type }) => (
 )
 
 FyndiqLogo.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number,
-  type: React.PropTypes.oneOf([
+  height: PropTypes.number,
+  width: PropTypes.number,
+  type: PropTypes.oneOf([
     'normal',
     'outline',
     'outline-transp',
@@ -30,7 +31,7 @@ FyndiqLogo.propTypes = {
     'outline-bw',
     'outline-transp-bw',
   ]),
-  className: React.PropTypes.string,
+  className: PropTypes.string,
 }
 
 FyndiqLogo.defaultProps = {

--- a/packages/fyndiq-icon-checkmark/src/index.js
+++ b/packages/fyndiq-icon-checkmark/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import colors from 'fyndiq-styles-colors'
 
 const Checkmark = ({ height, width, className, color }) => (
@@ -14,10 +15,10 @@ const Checkmark = ({ height, width, className, color }) => (
 )
 
 Checkmark.propTypes = {
-  height: React.PropTypes.number,
-  width: React.PropTypes.number,
-  className: React.PropTypes.string,
-  color: React.PropTypes.string,
+  height: PropTypes.number,
+  width: PropTypes.number,
+  className: PropTypes.string,
+  color: PropTypes.string,
 }
 
 Checkmark.defaultProps = {

--- a/packages/fyndiq-icon-star/src/index.js
+++ b/packages/fyndiq-icon-star/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import styles from '../styles.less'
 
 const Star = ({ full, onClick, onHover }) => {
@@ -29,9 +30,9 @@ const Star = ({ full, onClick, onHover }) => {
 }
 
 Star.propTypes = {
-  full: React.PropTypes.number,
-  onClick: React.PropTypes.func,
-  onHover: React.PropTypes.func,
+  full: PropTypes.number,
+  onClick: PropTypes.func,
+  onHover: PropTypes.func,
 }
 
 Star.defaultProps = {


### PR DESCRIPTION
## Overview

[Last week](https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html) React@15.5.0 was published. Among other things, the `React.PropTypes` object is now deprecated, and has been moved to its own package `prop-types`. This PR applies this change.

## How to test

- `npm i && npm test`
- Check that you get no warnings in the console