### PR TITLE
Add support for touch event for dropdown

### DIFF
--- a/packages/fyndiq-component-dropdown/src/index.js
+++ b/packages/fyndiq-component-dropdown/src/index.js
@@ -36,10 +36,12 @@ class Dropdown extends React.Component {
 
   componentWillMount() {
     document.addEventListener('click', this.boundHandler, false)
+    document.addEventListener('touchend', this.boundHandler, false)
   }
 
   componentWillUnmount() {
     document.removeEventListener('click', this.boundHandler, false)
+    document.removeEventListener('touchend', this.boundHandler, false)
   }
 
   onButtonClick() {


### PR DESCRIPTION
## Overview

Safari Mobile doesn't sent the "click" event every time, so we need to attach the dropdown closing handler to the `touchend` event too.