### PR TITLE
Checkbox update state props

### DIFF
--- a/packages/fyndiq-component-checkbox/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-checkbox/src/__snapshots__/index.test.js.snap
@@ -19,6 +19,48 @@ exports[`fyndiq-component-checkbox should be invoquable without parameters 1`] =
 </button>
 `;
 
+exports[`fyndiq-component-checkbox should be programatically checkable 1`] = `
+<Checkbox
+  checked={true}
+  className=""
+  color="#999"
+  disabled={false}
+  onToggle={[Function]}
+>
+  <button
+    className="
+            checkbox
+            interactiveCheckbox
+            
+          "
+    disabled={false}
+    onClick={[Function]}
+  >
+    <Checkmark
+      className="checkmark"
+      color="#999"
+      height={15}
+      width={15}
+    >
+      <svg
+        className="checkmark"
+        fill="#999"
+        height={15}
+        viewBox="0 0 50 50"
+        width={15}
+      >
+        <path
+          d="M16.8 42c-.4 0-1-.2-1.2-.5l-14-14.2c-.8-.7-.8-1.8 0-2.5.6-.7 1.7-.7 2.4 0l12.8 13 29-29c.7-.7 1.8-.7 2.5 0s.7 1.8 0 2.5L18 41.5c-.2.3-.7.5-1.2.5z"
+        />
+      </svg>
+    </Checkmark>
+    <span
+      className="children"
+    />
+  </button>
+</Checkbox>
+`;
+
 exports[`fyndiq-component-checkbox should have prop checked 1`] = `
 <button
   className="

--- a/packages/fyndiq-component-checkbox/src/index.js
+++ b/packages/fyndiq-component-checkbox/src/index.js
@@ -12,6 +12,14 @@ class Checkbox extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.checked !== nextProps.checked) {
+      this.setState({
+        checked: nextProps.checked,
+      })
+    }
+  }
+
   toggle() {
     const checked = !this.state.checked
     this.setState({

--- a/packages/fyndiq-component-checkbox/src/index.test.js
+++ b/packages/fyndiq-component-checkbox/src/index.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 
 import Checkbox from './'
 
@@ -47,6 +47,12 @@ describe('fyndiq-component-checkbox', () => {
     expect(component).toMatchSnapshot()
 
     component.simulate('click')
+    expect(component).toMatchSnapshot()
+  })
+
+  test('should be programatically checkable', () => {
+    const component = mount(<Checkbox />)
+    component.setProps({ checked: true })
     expect(component).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
## Overview

Right now, when the `checked` prop on a Checkbox is updated, it is not reflected in the state of the component. To fix this behavior, the handler `componentWillReceiveProps` is being used.