### PR TITLE
Allow text prop to be a Component for tooltip

### DIFF
--- a/packages/fyndiq-component-tooltip/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-tooltip/src/__snapshots__/index.test.js.snap
@@ -25,6 +25,33 @@ exports[`fyndiq-component-tooltip should be rendered without props 1`] = `
 </Dropdown>
 `;
 
+exports[`fyndiq-component-tooltip should have a component for the prop text 1`] = `
+<Dropdown
+  button={
+    <span>
+      tooltip
+    </span>
+  }
+  hoverMode={true}
+  margin={5}
+  noArrow={false}
+  noWrapperStyle={true}
+  opened={false}
+  position="bc"
+>
+  <div
+    className="
+          tooltip
+          position-bc
+        "
+  >
+    <div>
+      hello
+    </div>
+  </div>
+</Dropdown>
+`;
+
 exports[`fyndiq-component-tooltip should have the right position 1`] = `
 <Dropdown
   button={

--- a/packages/fyndiq-component-tooltip/src/index.js
+++ b/packages/fyndiq-component-tooltip/src/index.js
@@ -23,7 +23,7 @@ const Tooltip = ({ text, children, position }) => (
 )
 
 Tooltip.propTypes = {
-  text: PropTypes.string,
+  text: PropTypes.node,
   children: PropTypes.node,
   position: Dropdown.propTypes.position,
 }

--- a/packages/fyndiq-component-tooltip/src/index.test.js
+++ b/packages/fyndiq-component-tooltip/src/index.test.js
@@ -13,4 +13,10 @@ describe('fyndiq-component-tooltip', () => {
       <Tooltip text="help" position="tr">tooltip</Tooltip>
     )).toMatchSnapshot()
   })
+
+  test('should have a component for the prop text', () => {
+    expect(shallow(
+      <Tooltip text={<div>hello</div>}>tooltip</Tooltip>
+    )).toMatchSnapshot()
+  })
 })


### PR DESCRIPTION
## Overview

Right now the propType for `text` in the Tooltip component is `string`, which means that you can't pass a component without getting a warning in the console.

The use-case for this change is the following: I want to show some line-breaks in the tooltip component, but I can't do so in a proper way without using `<div>` components inside the `text` property.

What I want to achieve:
<img width="150" alt="screen shot 2017-07-06 at 09 04 35" src="https://user-images.githubusercontent.com/1416801/27899350-26b09118-622a-11e7-909b-6d90e2a4adfe.png">