### PR TITLE
Don't overwrite the product's onClick property

### DIFF
--- a/packages/fyndiq-component-productlist/src/wrapper.js
+++ b/packages/fyndiq-component-productlist/src/wrapper.js
@@ -58,7 +58,12 @@ export class Wrapper extends React.Component {
         {children.map((child, id) => React.cloneElement(child, {
           interactive: true,
           open: this.state.openedProducts.indexOf(id) !== -1,
-          onClick: () => this.toggleProduct(id),
+          onClick: () => {
+            // Toggle open this product
+            this.toggleProduct(id)
+            // Don't overwrite the products's onClick prop
+            child.props.onClick()
+          },
         }))}
       </div>
     )

--- a/packages/fyndiq-component-productlist/src/wrapper.test.js
+++ b/packages/fyndiq-component-productlist/src/wrapper.test.js
@@ -40,5 +40,23 @@ describe('fyndiq-component-productlist', () => {
       Component.find(ProductListItem).at(2).simulate('click')
       expect(Component.find(ProductListItem).at(1).prop('open')).toBeTruthy()
     })
+
+    test('should not overwrite onClick of a ProductListItem', () => {
+      const spy = jest.fn()
+      const products = [
+        ...ProductList,
+        <ProductListItem
+          key={1}
+          title="title1"
+          price="price1"
+          imageUrl="imageUrl1"
+          onClick={spy}
+        />,
+      ]
+
+      const Component = shallow(<Wrapper>{products}</Wrapper>)
+      Component.find(ProductListItem).at(3).simulate('click')
+      expect(spy).toHaveBeenCalled()
+    })
   })
 })


### PR DESCRIPTION
## Overview

Right now when putting a `<ProductListItem />` with a `onClick` property in a `<Wrapper />`, the property gets overwritten.
This PR fixes this behavior.

## How to test

The test case covers the new behavior