### PR TITLE
Button link

### DIFF
--- a/packages/fyndiq-component-button/README.md
+++ b/packages/fyndiq-component-button/README.md
@@ -41,6 +41,17 @@ import Button from 'fyndiq-component-button'
 
 // Disabled usage
 <Button disabled>My disabled Button</Button>
+
+// Render a link as a button
+<Button link="#hello">My link</Button>
+
+// Use a custom Link element
+import { Link } from 'react-router-dom
+<Button
+  link={<Link to="my/path" />}
+>
+  My link
+</Button>
 ```
 
 # API
@@ -50,8 +61,9 @@ The component `Button` has the following customizable props:
 | Name | Type | Description | Default value |
 |---|---|---|---|
 | **type** | String | One of `primary`, `cancel`, `blue`, `inverted`. Changes the color style of the button | `normal` |
-| **htmlType** | String | Set the original html type for `button`. See: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | `null` |
+| **htmlType** | String | Set the original html type for `button`. See: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | `undefined` |
 | **size** | String | One of `xs`, `s`, `l`, `xl`. Changes the size of the button | `m` |
 | **disabled** | Boolean | If true, will disable the button. | `false` |
 | **pressed** | Boolean | Show the button as pressed | `false` |
+| **link** | String or Element | Uses an `<a>` tag or a custom element to render the button | `undefined` |
 | **onClick** | Function | Callback when the button is pressed | `noop => noop` |

--- a/packages/fyndiq-component-button/README.md
+++ b/packages/fyndiq-component-button/README.md
@@ -46,7 +46,7 @@ import Button from 'fyndiq-component-button'
 <Button link="#hello">My link</Button>
 
 // Use a custom Link element
-import { Link } from 'react-router-dom
+import { Link } from 'react-router-dom'
 <Button
   link={<Link to="my/path" />}
 >

--- a/packages/fyndiq-component-button/README.md
+++ b/packages/fyndiq-component-button/README.md
@@ -50,6 +50,7 @@ The component `Button` has the following customizable props:
 | Name | Type | Description | Default value |
 |---|---|---|---|
 | **type** | String | One of `primary`, `cancel`, `blue`, `inverted`. Changes the color style of the button | `normal` |
+| **htmlType** | String | Set the original html type for `button`. See: [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-type) | `null` |
 | **size** | String | One of `xs`, `s`, `l`, `xl`. Changes the size of the button | `m` |
 | **disabled** | Boolean | If true, will disable the button. | `false` |
 | **pressed** | Boolean | Show the button as pressed | `false` |

--- a/packages/fyndiq-component-button/package.json
+++ b/packages/fyndiq-component-button/package.json
@@ -13,6 +13,7 @@
     "fyndiq-styles-colors": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "prop-types": "^15.0.0",
+    "react": "^15.0.0"
   }
 }

--- a/packages/fyndiq-component-button/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-button/src/__snapshots__/index.test.js.snap
@@ -45,7 +45,6 @@ exports[`fyndiq-component-button should be rendered without props 1`] = `
   "
   disabled={false}
   onClick={[Function]}
-  type={null}
 >
   Hello
 </button>
@@ -63,7 +62,6 @@ exports[`fyndiq-component-button should have a disabled prop 1`] = `
   "
   disabled={true}
   onClick={[Function]}
-  type={null}
 >
   Hello
 </button>
@@ -81,7 +79,6 @@ exports[`fyndiq-component-button should have a horizontal prop 1`] = `
   "
   disabled={false}
   onClick={[Function]}
-  type={null}
 >
   Hello
 </button>
@@ -117,7 +114,6 @@ exports[`fyndiq-component-button should have a pressed prop 1`] = `
   "
   disabled={false}
   onClick={[Function]}
-  type={null}
 >
   Hello
 </button>
@@ -135,7 +131,6 @@ exports[`fyndiq-component-button should have a size prop 1`] = `
   "
   disabled={false}
   onClick={[Function]}
-  type={null}
 >
   Hello
 </button>
@@ -153,7 +148,6 @@ exports[`fyndiq-component-button should have a type prop 1`] = `
   "
   disabled={false}
   onClick={[Function]}
-  type={null}
 >
   Hello
 </button>

--- a/packages/fyndiq-component-button/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-button/src/__snapshots__/index.test.js.snap
@@ -12,6 +12,7 @@ exports[`fyndiq-component-button should be rendered without props 1`] = `
     "
   disabled={false}
   onClick={[Function]}
+  type={null}
 >
   Hello
 </button>
@@ -29,6 +30,7 @@ exports[`fyndiq-component-button should have a disabled prop 1`] = `
     "
   disabled={true}
   onClick={[Function]}
+  type={null}
 >
   Hello
 </button>
@@ -46,6 +48,25 @@ exports[`fyndiq-component-button should have a horizontal prop 1`] = `
     "
   disabled={false}
   onClick={[Function]}
+  type={null}
+>
+  Hello
+</button>
+`;
+
+exports[`fyndiq-component-button should have a htmlType prop 1`] = `
+<button
+  className="
+      button
+      type-normal
+      size-s
+      false
+      false
+      interactive
+    "
+  disabled={false}
+  onClick={[Function]}
+  type="submit"
 >
   Hello
 </button>
@@ -63,6 +84,7 @@ exports[`fyndiq-component-button should have a pressed prop 1`] = `
     "
   disabled={false}
   onClick={[Function]}
+  type={null}
 >
   Hello
 </button>
@@ -80,6 +102,7 @@ exports[`fyndiq-component-button should have a size prop 1`] = `
     "
   disabled={false}
   onClick={[Function]}
+  type={null}
 >
   Hello
 </button>
@@ -97,6 +120,7 @@ exports[`fyndiq-component-button should have a type prop 1`] = `
     "
   disabled={false}
   onClick={[Function]}
+  type={null}
 >
   Hello
 </button>

--- a/packages/fyndiq-component-button/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-button/src/__snapshots__/index.test.js.snap
@@ -1,15 +1,48 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`fyndiq-component-button should be renderable as a custom link element 1`] = `
+<Link
+  className="
+    button
+    type-normal
+    size-s
+    false
+    false
+    interactive
+  "
+  to="my/path"
+>
+  Hello
+</Link>
+`;
+
+exports[`fyndiq-component-button should be renderable as a link 1`] = `
+<a
+  className="
+    button
+    type-normal
+    size-s
+    false
+    false
+    interactive
+  "
+  href="#hello"
+  onClick={[Function]}
+>
+  Hello
+</a>
+`;
+
 exports[`fyndiq-component-button should be rendered without props 1`] = `
 <button
   className="
-      button
-      type-normal
-      size-s
-      false
-      false
-      interactive
-    "
+    button
+    type-normal
+    size-s
+    false
+    false
+    interactive
+  "
   disabled={false}
   onClick={[Function]}
   type={null}
@@ -21,13 +54,13 @@ exports[`fyndiq-component-button should be rendered without props 1`] = `
 exports[`fyndiq-component-button should have a disabled prop 1`] = `
 <button
   className="
-      button
-      type-normal
-      size-s
-      false
-      false
-      disabled
-    "
+    button
+    type-normal
+    size-s
+    false
+    false
+    disabled
+  "
   disabled={true}
   onClick={[Function]}
   type={null}
@@ -39,13 +72,13 @@ exports[`fyndiq-component-button should have a disabled prop 1`] = `
 exports[`fyndiq-component-button should have a horizontal prop 1`] = `
 <button
   className="
-      button
-      type-normal
-      size-s
-      horizontal
-      false
-      interactive
-    "
+    button
+    type-normal
+    size-s
+    horizontal
+    false
+    interactive
+  "
   disabled={false}
   onClick={[Function]}
   type={null}
@@ -57,13 +90,13 @@ exports[`fyndiq-component-button should have a horizontal prop 1`] = `
 exports[`fyndiq-component-button should have a htmlType prop 1`] = `
 <button
   className="
-      button
-      type-normal
-      size-s
-      false
-      false
-      interactive
-    "
+    button
+    type-normal
+    size-s
+    false
+    false
+    interactive
+  "
   disabled={false}
   onClick={[Function]}
   type="submit"
@@ -75,13 +108,13 @@ exports[`fyndiq-component-button should have a htmlType prop 1`] = `
 exports[`fyndiq-component-button should have a pressed prop 1`] = `
 <button
   className="
-      button
-      type-normal
-      size-s
-      false
-      pressed
-      interactive
-    "
+    button
+    type-normal
+    size-s
+    false
+    pressed
+    interactive
+  "
   disabled={false}
   onClick={[Function]}
   type={null}
@@ -93,13 +126,13 @@ exports[`fyndiq-component-button should have a pressed prop 1`] = `
 exports[`fyndiq-component-button should have a size prop 1`] = `
 <button
   className="
-      button
-      type-normal
-      size-xs
-      false
-      false
-      interactive
-    "
+    button
+    type-normal
+    size-xs
+    false
+    false
+    interactive
+  "
   disabled={false}
   onClick={[Function]}
   type={null}
@@ -111,13 +144,13 @@ exports[`fyndiq-component-button should have a size prop 1`] = `
 exports[`fyndiq-component-button should have a type prop 1`] = `
 <button
   className="
-      button
-      type-primary
-      size-s
-      false
-      false
-      interactive
-    "
+    button
+    type-primary
+    size-s
+    false
+    false
+    interactive
+  "
   disabled={false}
   onClick={[Function]}
   type={null}

--- a/packages/fyndiq-component-button/src/index.js
+++ b/packages/fyndiq-component-button/src/index.js
@@ -11,23 +11,54 @@ const Button = ({
   disabled,
   pressed,
   htmlType,
-}) => (
-  <button
-    className={`
-      ${styles.button}
-      ${styles['type-' + type]}
-      ${styles['size-' + size]}
-      ${horizontal && styles.horizontal}
-      ${pressed && styles.pressed}
-      ${disabled ? styles.disabled : styles.interactive}
-    `}
-    onClick={onClick}
-    disabled={disabled}
-    type={htmlType}
-  >
-    {children}
-  </button>
-)
+  link,
+}) => {
+  const className = `
+    ${styles.button}
+    ${styles['type-' + type]}
+    ${styles['size-' + size]}
+    ${horizontal && styles.horizontal}
+    ${pressed && styles.pressed}
+    ${disabled ? styles.disabled : styles.interactive}
+  `
+
+  // If the button is a link defined as a string,
+  // render the button as an <a> tag
+  if (typeof link === 'string') {
+    return (
+      <a
+        className={className}
+        onClick={onClick}
+        href={link}
+      >
+        {children}
+      </a>
+    )
+  // If the link is a React Element
+  // This case is usefull for integrating with react-router API
+  } else if (React.isValidElement(link)) {
+    return (
+      React.cloneElement(link, {
+        // Just pass the children and the className to the
+        // custom link element
+        className,
+        children,
+      })
+    )
+  }
+
+  // Default case: render a button.
+  return (
+    <button
+      className={className}
+      onClick={onClick}
+      disabled={disabled}
+      type={htmlType}
+    >
+      {children}
+    </button>
+  )
+}
 
 Button.propTypes = {
   children: PropTypes.node.isRequired,
@@ -38,6 +69,10 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   pressed: PropTypes.bool,
   htmlType: PropTypes.string,
+  link: PropTypes.oneOfType(
+    PropTypes.string,
+    PropTypes.element,
+  ),
 }
 
 Button.defaultProps = {
@@ -47,7 +82,8 @@ Button.defaultProps = {
   horizontal: false,
   disabled: false,
   pressed: false,
-  htmlType: null,
+  htmlType: undefined,
+  link: undefined,
 }
 
 export default Button

--- a/packages/fyndiq-component-button/src/index.js
+++ b/packages/fyndiq-component-button/src/index.js
@@ -2,7 +2,16 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styles from '../styles.less'
 
-const Button = ({ children, onClick, type, size, horizontal, disabled, pressed }) => (
+const Button = ({
+  children,
+  onClick,
+  type,
+  size,
+  horizontal,
+  disabled,
+  pressed,
+  htmlType,
+}) => (
   <button
     className={`
       ${styles.button}
@@ -14,6 +23,7 @@ const Button = ({ children, onClick, type, size, horizontal, disabled, pressed }
     `}
     onClick={onClick}
     disabled={disabled}
+    type={htmlType}
   >
     {children}
   </button>
@@ -27,6 +37,7 @@ Button.propTypes = {
   horizontal: PropTypes.bool,
   disabled: PropTypes.bool,
   pressed: PropTypes.bool,
+  htmlType: PropTypes.string,
 }
 
 Button.defaultProps = {
@@ -36,6 +47,7 @@ Button.defaultProps = {
   horizontal: false,
   disabled: false,
   pressed: false,
+  htmlType: null,
 }
 
 export default Button

--- a/packages/fyndiq-component-button/src/index.js
+++ b/packages/fyndiq-component-button/src/index.js
@@ -69,10 +69,10 @@ Button.propTypes = {
   disabled: PropTypes.bool,
   pressed: PropTypes.bool,
   htmlType: PropTypes.string,
-  link: PropTypes.oneOfType(
+  link: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.element,
-  ),
+  ]),
 }
 
 Button.defaultProps = {

--- a/packages/fyndiq-component-button/src/index.test.js
+++ b/packages/fyndiq-component-button/src/index.test.js
@@ -39,6 +39,24 @@ describe('fyndiq-component-button', () => {
     expect(component).toMatchSnapshot()
   })
 
+  test('should be renderable as a link', () => {
+    const component = shallow(<Button link="#hello">Hello</Button>)
+    expect(component).toMatchSnapshot()
+  })
+
+  test('should be renderable as a custom link element', () => {
+    // Create Link element that follows react-router API
+    const Link = ({ to, children }) => (
+      <a href={to}>
+        {children}
+      </a>
+    )
+    const component = shallow(<Button link={<Link to="my/path" />}>
+      Hello
+    </Button>)
+    expect(component).toMatchSnapshot()
+  })
+
   test('should call the onClick handler when clicked on', () => {
     const clickSpy = jest.fn()
     const component = shallow(<Button onClick={clickSpy}>Hello</Button>)

--- a/packages/fyndiq-component-button/src/index.test.js
+++ b/packages/fyndiq-component-button/src/index.test.js
@@ -34,6 +34,11 @@ describe('fyndiq-component-button', () => {
     expect(component).toMatchSnapshot()
   })
 
+  test('should have a htmlType prop', () => {
+    const component = shallow(<Button htmlType="submit">Hello</Button>)
+    expect(component).toMatchSnapshot()
+  })
+
   test('should call the onClick handler when clicked on', () => {
     const clickSpy = jest.fn()
     const component = shallow(<Button onClick={clickSpy}>Hello</Button>)

--- a/packages/fyndiq-component-button/styles.less
+++ b/packages/fyndiq-component-button/styles.less
@@ -7,6 +7,7 @@
   background-color: @palegrey;
   color: @black;
   font-family: inherit;
+  text-decoration: none;
 
   &:focus {
     outline: 0;

--- a/packages/fyndiq-component-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-dropdown/src/__snapshots__/index.test.js.snap
@@ -16,7 +16,6 @@ exports[`fyndiq-component-dropdown should be displayed with minimum props 1`] = 
     <Button
       disabled={false}
       horizontal={false}
-      htmlType={null}
       onClick={[Function]}
       pressed={false}
       size="s"

--- a/packages/fyndiq-component-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-dropdown/src/__snapshots__/index.test.js.snap
@@ -16,6 +16,7 @@ exports[`fyndiq-component-dropdown should be displayed with minimum props 1`] = 
     <Button
       disabled={false}
       horizontal={false}
+      htmlType={null}
       onClick={[Function]}
       pressed={false}
       size="s"

--- a/packages/fyndiq-ui-test/stories/component-button.js
+++ b/packages/fyndiq-ui-test/stories/component-button.js
@@ -32,5 +32,5 @@ storiesOf('Button', module)
     <Button disabled>Disabled Button</Button>
   ))
   .addWithInfo('<a> tag', () => (
-    <Button href="#hello">I am a link</Button>
+    <Button link="#hello">I am a link</Button>
   ))

--- a/packages/fyndiq-ui-test/stories/component-button.js
+++ b/packages/fyndiq-ui-test/stories/component-button.js
@@ -31,3 +31,6 @@ storiesOf('Button', module)
   .addWithInfo('disabled button', () => (
     <Button disabled>Disabled Button</Button>
   ))
+  .addWithInfo('<a> tag', () => (
+    <Button href="#hello">I am a link</Button>
+  ))


### PR DESCRIPTION
## Overview


### `link` prop
This PR adds support for links to the `<Button />` component. It adds 2 modes for the new `link` prop:

- String Mode

``` js
<Button link="my/path">
  My link
</Button>
// Renders an <a> tag instead of a <button>
```

- Component Mode

``` js
import { Link } from 'react-router-dom'

<Button link={<Link to="my/path" />}>
  My Link
</Button>
// Delegates the rendering to the custom component
```

### `htmlType` prop

This PR introduces a new prop for the Button Component: `htmlType`. When providing a string value to this prop, the `<button>` element will have an HTML `type` attribute.
This prop follows the API from [Ant-D](https://ant.design/components/button/#API)

### Other changes

This PR drops support for React@v0.14, and also adds `prop-types` package as a **peerDependency** for the Button Component. This change is considered non-breaking because we never supported React@v0.14.