### PR TITLE
Peerdependencies update

### DIFF
--- a/packages/fyndiq-component-alert/package.json
+++ b/packages/fyndiq-component-alert/package.json
@@ -13,6 +13,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-button/package.json
+++ b/packages/fyndiq-component-button/package.json
@@ -13,7 +13,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "prop-types": "^15.0.0",
-    "react": "^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-checkbox/package.json
+++ b/packages/fyndiq-component-checkbox/package.json
@@ -14,6 +14,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-dropdown/package.json
+++ b/packages/fyndiq-component-dropdown/package.json
@@ -15,6 +15,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-price/package.json
+++ b/packages/fyndiq-component-price/package.json
@@ -13,6 +13,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-productcard/package.json
+++ b/packages/fyndiq-component-productcard/package.json
@@ -15,6 +15,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-productlist/package.json
+++ b/packages/fyndiq-component-productlist/package.json
@@ -16,7 +16,12 @@
     "fyndiq-styles-medias": "*"
   },
   "peerDependencies": {
+    "css-loader": "^0.28.7",
     "moment": "^2.18.1",
-    "react": "^0.14.0 || ^15.0.0"
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-stars/package.json
+++ b/packages/fyndiq-component-stars/package.json
@@ -13,6 +13,11 @@
     "fyndiq-styles-colors": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-component-tooltip/package.json
+++ b/packages/fyndiq-component-tooltip/package.json
@@ -14,6 +14,11 @@
     "fyndiq-styles-colors": "*"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-icon-arrow/package.json
+++ b/packages/fyndiq-icon-arrow/package.json
@@ -10,6 +10,11 @@
   },
   "homepage": "https://github.com/fyndiq/fyndiq-ui",
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-icon-brand/package.json
+++ b/packages/fyndiq-icon-brand/package.json
@@ -13,6 +13,11 @@
     "fyndiq-styles-colors": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-icon-checkmark/package.json
+++ b/packages/fyndiq-icon-checkmark/package.json
@@ -13,6 +13,7 @@
     "fyndiq-styles-colors": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-icon-loader/package.json
+++ b/packages/fyndiq-icon-loader/package.json
@@ -13,6 +13,11 @@
     "fyndiq-styles-colors": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }

--- a/packages/fyndiq-icon-star/package.json
+++ b/packages/fyndiq-icon-star/package.json
@@ -13,6 +13,11 @@
     "fyndiq-styles-colors": "^1.1.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.5.10",
+    "react": "^15.6.1"
   }
 }


### PR DESCRIPTION
## Overview

Updated peerdependencies:

- Drop support for outdated React version
- Add **`prop-types`** peerDependency (this one was missing for a long time)
- Add CSS and PostCSS toolchain peerDependencies

This PR is built on top of #27 and uses the PostCSS toolchain.

## What's new

When a user tries to `npm install` a Fyndiq Component, he will be warned about a missing or incompatible package (React, css-loader, postcss-loader, postcss-cssnext, ...) if the main project doesn't depend on it.

Closes #28 