### PR TITLE
Add ESLint Jest Plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
-  extends: 'fyndiq',
+  extends: ['fyndiq', 'plugin:jest/recommended'],
+  plugins: ['jest'],
   rules: {
     // This rules causes issues because of nested packages.json, disabling
     'import/no-extraneous-dependencies': 0,

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^4.5.0",
     "eslint-config-fyndiq": "^0.1.0",
     "eslint-plugin-import": "^2.2.0",
+    "eslint-plugin-jest": "^21.1.0",
     "eslint-plugin-jsx-a11y": "^5.1.1",
     "eslint-plugin-react": "^7.3.0",
     "file-loader": "^0.11.2",

--- a/packages/fyndiq-component-stars/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-stars/src/__snapshots__/index.test.js.snap
@@ -1,5 +1,47 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`fyndiq-component-stars should be rendered with prop interactive 1`] = `
+<div
+  className="wrapper"
+>
+  <div
+    className="
+              stars
+              interactive
+              size-m
+            "
+    data-test="STARS"
+    onMouseLeave={[Function]}
+  >
+    <Star
+      full={NaN}
+      onClick={[Function]}
+      onHover={[Function]}
+    />
+    <Star
+      full={NaN}
+      onClick={[Function]}
+      onHover={[Function]}
+    />
+    <Star
+      full={NaN}
+      onClick={[Function]}
+      onHover={[Function]}
+    />
+    <Star
+      full={NaN}
+      onClick={[Function]}
+      onHover={[Function]}
+    />
+    <Star
+      full={NaN}
+      onClick={[Function]}
+      onHover={[Function]}
+    />
+  </div>
+</div>
+`;
+
 exports[`fyndiq-component-stars should be rendered with prop rating 1`] = `
 <div
   className="wrapper"
@@ -88,48 +130,6 @@ exports[`fyndiq-component-stars should be rendered with prop reviews 1`] = `
     4
      reviews)
   </span>
-</div>
-`;
-
-exports[`fyndiq-component-stars should be rendered with prop reviews 2`] = `
-<div
-  className="wrapper"
->
-  <div
-    className="
-              stars
-              interactive
-              size-m
-            "
-    data-test="STARS"
-    onMouseLeave={[Function]}
-  >
-    <Star
-      full={NaN}
-      onClick={[Function]}
-      onHover={[Function]}
-    />
-    <Star
-      full={NaN}
-      onClick={[Function]}
-      onHover={[Function]}
-    />
-    <Star
-      full={NaN}
-      onClick={[Function]}
-      onHover={[Function]}
-    />
-    <Star
-      full={NaN}
-      onClick={[Function]}
-      onHover={[Function]}
-    />
-    <Star
-      full={NaN}
-      onClick={[Function]}
-      onHover={[Function]}
-    />
-  </div>
 </div>
 `;
 

--- a/packages/fyndiq-component-stars/src/index.test.js
+++ b/packages/fyndiq-component-stars/src/index.test.js
@@ -27,7 +27,7 @@ describe('fyndiq-component-stars', () => {
     expect(component).toMatchSnapshot()
   })
 
-  it('should be rendered with prop reviews', () => {
+  it('should be rendered with prop interactive', () => {
     const component = shallow(<Stars interactive />)
     expect(component).toMatchSnapshot()
   })


### PR DESCRIPTION
## Overview

This PR adds [**`eslint-plugin-jest`**](https://github.com/facebook/jest/tree/master/packages/eslint-plugin-jest) as well as the recommended [rules](https://github.com/facebook/jest/tree/master/packages/eslint-plugin-jest/docs/rules) to the repo.

This plugin catched one error: 2 tests were named the same. This has been fixed.