### PR TITLE
Fix storybook port

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,6 @@ npm run bootstrap
 npm run dev
 ```
 
+The Storybook will be available on port `6006`.
+
 To create a new component, create a new folder in the `packages/` directory and put your code in `src/`. Then, add your newly created package to the dependencies of `fyndiq-ui-test`'s package.json file, run `npm run bootstrap` and restart `npm run dev`.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "lerna exec --ignore fyndiq-ui-test -- babel src -d lib --ignore *.test.js",
     "build:watch": "lerna exec --parallel --ignore fyndiq-ui-test -- babel src -d lib --ignore *.test.js -w",
     "publish": "npm run build && lerna publish",
-    "dev": "npm run build:watch & lerna run storybook",
+    "dev": "npm run build:watch & lerna run storybook --stream --scope fyndiq-ui-test",
     "lerna": "lerna",
     "lint": "npm run lint:js && npm run lint:less",
     "lint:js": "eslint --cache --ignore-pattern coverage --ignore-pattern node_modules --ignore-pattern lib .",


### PR DESCRIPTION
## Overview

This PR highlights on which port is Storybook running, because it is confusing right now.

It now shows the port in 2 different places: in the README and in the terminal, when running `npm run dev`:
![storybook-port](https://user-images.githubusercontent.com/1416801/30809343-a78a59a6-a201-11e7-8ac0-b9f8556cea22.gif)


Link to the kangaroo gif for all the kangaroo lovers out here: https://gfycat.com/gifs/detail/somberdismaldromedary
