### PR TITLE
Upgrade to React@v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,8 +27,9 @@
     "babel-preset-react": "^6.23.0",
     "babel-preset-stage-0": "^6.22.0",
     "coveralls": "^2.13.1",
-    "enzyme": "^2.8.1",
-    "enzyme-to-json": "^1.5.0",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.1",
+    "enzyme-to-json": "^3.1.2",
     "eslint": "^4.5.0",
     "eslint-config-fyndiq": "^0.1.0",
     "eslint-plugin-import": "^2.2.0",
@@ -40,25 +41,30 @@
     "jest": "^20.0.0",
     "lerna": "^2.2.0",
     "mock-local-storage": "^1.0.4",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2",
-    "react-test-renderer": "^15.5.4",
+    "raf": "^3.4.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1"
   },
   "dependencies": {
     "@storybook/addon-info": "^3.1.9",
-    "@storybook/react": "^3.2.8",
+    "@storybook/react": "^3.2.12",
     "css-loader": "^0.28.7",
     "postcss-cssnext": "^3.0.2",
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
-    "prop-types": "^15.5.6",
+    "prop-types": "^15.6.0",
     "style-loader": "^0.18.2",
     "stylelint": "~8.0.0",
     "stylelint-config-standard": "~17.0.0"
   },
   "jest": {
-    "setupTestFrameworkScriptFile": "mock-local-storage",
+    "setupFiles": [
+      "mock-local-storage",
+      "raf/polyfill",
+      "./setup-test.js"
+    ],
     "snapshotSerializers": [
       "enzyme-to-json/serializer"
     ],

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jest": "^20.0.0",
     "lerna": "^2.2.0",
     "mock-local-storage": "^1.0.4",
+    "moment": "^2.18.1",
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "jest": "^20.0.0",
     "lerna": "^2.2.0",
     "mock-local-storage": "^1.0.4",
-    "moment": "^2.18.1",
+    "moment": "~2.18.1",
     "raf": "^3.4.0",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",

--- a/packages/fyndiq-component-alert/package.json
+++ b/packages/fyndiq-component-alert/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-alert/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-alert/src/__snapshots__/index.test.js.snap
@@ -32,6 +32,7 @@ exports[`fyndiq-component-alert should be rendered without props 1`] = `
 exports[`fyndiq-component-alert should be self-closable 1`] = `
 <Alert
   onClose={[Function]}
+  stopShowingAfter={undefined}
   stopShowingAfterKey=""
   type="info"
   unclosable={false}
@@ -66,6 +67,7 @@ exports[`fyndiq-component-alert should be self-closable 1`] = `
 exports[`fyndiq-component-alert should be self-closable 2`] = `
 <Alert
   onClose={[Function]}
+  stopShowingAfter={undefined}
   stopShowingAfterKey=""
   type="info"
   unclosable={false}

--- a/packages/fyndiq-component-alert/src/index.test.js
+++ b/packages/fyndiq-component-alert/src/index.test.js
@@ -22,8 +22,10 @@ describe('fyndiq-component-alert', () => {
     const component = mount(<Alert />)
     component.find('.close').simulate('click')
     jest.runTimersToTime(50)
+    component.update()
     expect(component).toMatchSnapshot()
     jest.runTimersToTime(500)
+    component.update()
     expect(component).toMatchSnapshot()
   })
 

--- a/packages/fyndiq-component-button/package.json
+++ b/packages/fyndiq-component-button/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-checkbox/package.json
+++ b/packages/fyndiq-component-checkbox/package.json
@@ -19,6 +19,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-dropdown/package.json
+++ b/packages/fyndiq-component-dropdown/package.json
@@ -20,6 +20,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-dropdown/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-dropdown/src/__snapshots__/index.test.js.snap
@@ -1,9 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`fyndiq-component-dropdown should be closable by pressing the Escape key 1`] = `""`;
-
-exports[`fyndiq-component-dropdown should be closed when clicking outside 1`] = `""`;
-
 exports[`fyndiq-component-dropdown should be displayed with minimum props 1`] = `
 <div
   className="wrapper"
@@ -66,8 +62,6 @@ exports[`fyndiq-component-dropdown should be opened when hovered, if in hoverMod
   Value
 </div>
 `;
-
-exports[`fyndiq-component-dropdown should be opened when hovered, if in hoverMode 2`] = `""`;
 
 exports[`fyndiq-component-dropdown should have a custom button 1`] = `
 <div

--- a/packages/fyndiq-component-dropdown/src/index.test.js
+++ b/packages/fyndiq-component-dropdown/src/index.test.js
@@ -18,20 +18,25 @@ document.removeEventListener = jest.fn((event, cb) => {
 
 describe('fyndiq-component-dropdown', () => {
   test('should be displayed with minimum props', () => {
-    expect(shallow(<Dropdown button="Button">Value</Dropdown>)).toMatchSnapshot()
+    expect(shallow(
+      <Dropdown button="Button">Value</Dropdown>,
+      { disableLifecycleMethods: true },
+    )).toMatchSnapshot()
   })
 
   test('should have a custom button', () => {
     expect(shallow(
       <Dropdown button={<div>Hello</div>}>
         Value
-      </Dropdown>
+      </Dropdown>,
+      { disableLifecycleMethods: true }
     )).toMatchSnapshot()
   })
 
   test('should have a custom wrapper', () => {
     expect(shallow(
-      <Dropdown button="B" noWrapperStyle opened>Content</Dropdown>
+      <Dropdown button="B" noWrapperStyle opened>Content</Dropdown>,
+      { disableLifecycleMethods: true }
     ).find('.dropdownWrapper')).toMatchSnapshot()
   })
 
@@ -45,7 +50,8 @@ describe('fyndiq-component-dropdown', () => {
     const component = mount(<Dropdown button="button">Value</Dropdown>)
     component.find('div > div').at(0).simulate('click')
     simulate.click('body')
-    expect(component.find('.dropdownWrapper')).toMatchSnapshot()
+    component.update()
+    expect(component.find('.dropdownWrapper').exists()).toBe(false)
   })
 
   test('should be opened when hovered, if in hoverMode', () => {
@@ -53,10 +59,12 @@ describe('fyndiq-component-dropdown', () => {
     const component = mount(<Dropdown button="button" hoverMode>Value</Dropdown>)
     component.simulate('mouseover')
     jest.runTimersToTime(200)
+    component.update()
     expect(component.find('.dropdownWrapper')).toMatchSnapshot()
     component.simulate('mouseout')
     jest.runTimersToTime(100)
-    expect(component.find('.dropdownWrapper')).toMatchSnapshot()
+    component.update()
+    expect(component.find('.dropdownWrapper').exists()).toBe(false)
   })
 
   test('should open the dropdown on button click in hoverMode', () => {
@@ -84,7 +92,8 @@ describe('fyndiq-component-dropdown', () => {
 
   test('should have an arrow oriented to the top if dropdown is above', () => {
     expect(shallow(
-      <Dropdown button="B" position="tr" opened>Content</Dropdown>
+      <Dropdown button="B" position="tr" opened>Content</Dropdown>,
+      { disableLifecycleMethods: true },
     ).find('Arrow')).toMatchSnapshot()
   })
 
@@ -92,7 +101,8 @@ describe('fyndiq-component-dropdown', () => {
     const component = mount(<Dropdown button="button">Content</Dropdown>)
     component.find('div > div').at(0).simulate('click')
     simulate.keyup({ keyCode: 27 })
-    expect(component.find('.dropdownWrapper')).toMatchSnapshot()
+    component.update()
+    expect(component.find('.dropdownWrapper').exists()).toBe(false)
   })
 
   test('should remove eventListeners when unmounted', () => {

--- a/packages/fyndiq-component-price/package.json
+++ b/packages/fyndiq-component-price/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-productcard/package.json
+++ b/packages/fyndiq-component-productcard/package.json
@@ -20,6 +20,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-productlist/package.json
+++ b/packages/fyndiq-component-productlist/package.json
@@ -22,6 +22,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-productlist/src/__snapshots__/item.test.js.snap
+++ b/packages/fyndiq-component-productlist/src/__snapshots__/item.test.js.snap
@@ -216,6 +216,7 @@ exports[`fyndiq-component-productlist ProductListItem should have additionnal da
   </li>
   <li
     className="labelWrapper"
+    key="label1"
   >
     <span
       className="label"
@@ -230,6 +231,7 @@ exports[`fyndiq-component-productlist ProductListItem should have additionnal da
   </li>
   <li
     className="labelWrapper"
+    key="label2"
   >
     <span
       className="label"

--- a/packages/fyndiq-component-productlist/src/__snapshots__/wrapper.test.js.snap
+++ b/packages/fyndiq-component-productlist/src/__snapshots__/wrapper.test.js.snap
@@ -11,6 +11,7 @@ exports[`fyndiq-component-productlist Wrapper should display ProductListItem 1`]
     dealType={null}
     imageUrl="imageUrl1"
     interactive={true}
+    key="1"
     oldPrice={null}
     onClick={[Function]}
     open={false}
@@ -29,6 +30,7 @@ exports[`fyndiq-component-productlist Wrapper should display ProductListItem 1`]
     dealType={null}
     imageUrl="imageUrl2"
     interactive={true}
+    key="2"
     oldPrice={null}
     onClick={[Function]}
     open={false}
@@ -47,6 +49,7 @@ exports[`fyndiq-component-productlist Wrapper should display ProductListItem 1`]
     dealType={null}
     imageUrl="imageUrl3"
     interactive={true}
+    key="3"
     oldPrice={null}
     onClick={[Function]}
     open={false}

--- a/packages/fyndiq-component-stars/package.json
+++ b/packages/fyndiq-component-stars/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-component-stars/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-stars/src/__snapshots__/index.test.js.snap
@@ -15,26 +15,31 @@ exports[`fyndiq-component-stars should be rendered with prop interactive 1`] = `
   >
     <Star
       full={NaN}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -57,26 +62,31 @@ exports[`fyndiq-component-stars should be rendered with prop rating 1`] = `
   >
     <Star
       full={1}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={0.5}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -99,26 +109,31 @@ exports[`fyndiq-component-stars should be rendered with prop reviews 1`] = `
   >
     <Star
       full={NaN}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -148,26 +163,31 @@ exports[`fyndiq-component-stars should be rendered with prop size 1`] = `
   >
     <Star
       full={NaN}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -190,26 +210,31 @@ exports[`fyndiq-component-stars should be rendered without props 1`] = `
   >
     <Star
       full={NaN}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={NaN}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -232,26 +257,31 @@ exports[`fyndiq-component-stars should change its state when hovered and interac
   >
     <Star
       full={1}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={0}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={0}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -274,26 +304,31 @@ exports[`fyndiq-component-stars should not change its state when hovered and not
   >
     <Star
       full={1}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={0}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />
@@ -316,26 +351,31 @@ exports[`fyndiq-component-stars should reset its state when the mouse leaves 1`]
   >
     <Star
       full={1}
+      key="1"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="2"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="3"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={1}
+      key="4"
       onClick={[Function]}
       onHover={[Function]}
     />
     <Star
       full={0.2999999999999998}
+      key="5"
       onClick={[Function]}
       onHover={[Function]}
     />

--- a/packages/fyndiq-component-tooltip/package.json
+++ b/packages/fyndiq-component-tooltip/package.json
@@ -19,6 +19,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-icon-arrow/package.json
+++ b/packages/fyndiq-icon-arrow/package.json
@@ -15,6 +15,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-icon-brand/package.json
+++ b/packages/fyndiq-icon-brand/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-icon-checkmark/package.json
+++ b/packages/fyndiq-icon-checkmark/package.json
@@ -14,6 +14,6 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-icon-loader/package.json
+++ b/packages/fyndiq-icon-loader/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-icon-star/package.json
+++ b/packages/fyndiq-icon-star/package.json
@@ -18,6 +18,6 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.5.10",
-    "react": "^15.6.1"
+    "react": "^15.6.1 || ^16.0.0"
   }
 }

--- a/packages/fyndiq-styles-fonts/declarations.css
+++ b/packages/fyndiq-styles-fonts/declarations.css
@@ -2,19 +2,19 @@
   font-family: 'MuseoSans';
   font-style: normal;
   font-weight: 500;
-  src: url('\./fonts/MuseoSans-500.eot') format('embedded-opentype'), url('\./fonts/MuseoSans-500.woff') format('woff');
+  src: url('./fonts/MuseoSans-500.eot') format('embedded-opentype'), url('./fonts/MuseoSans-500.woff') format('woff');
 }
 
 @font-face {
   font-family: 'MuseoSans';
   font-style: normal;
   font-weight: 900;
-  src: url('\./fonts/MuseoSans-900.eot') format('embedded-opentype'), url('\./fonts/MuseoSans-900.woff') format('woff');
+  src: url('./fonts/MuseoSans-900.eot') format('embedded-opentype'), url('./fonts/MuseoSans-900.woff') format('woff');
 }
 
 @font-face {
   font-family: 'Cubano';
   font-style: normal;
   font-weight: normal;
-  src: url('\./fonts/cubano-regular-webfont.eot') format('embedded-opentype'), url('\./fonts/cubano-regular-webfont.woff') format('woff');
+  src: url('./fonts/cubano-regular-webfont.eot') format('embedded-opentype'), url('./fonts/cubano-regular-webfont.woff') format('woff');
 }

--- a/packages/fyndiq-ui-test/package.json
+++ b/packages/fyndiq-ui-test/package.json
@@ -19,9 +19,7 @@
     "fyndiq-styles-fonts": "^2.0.0"
   },
   "devDependencies": {
-    "moment": "^2.18.1",
-    "react": "^15.4.2",
-    "react-dom": "^15.4.2"
+    
   },
   "scripts": {
     "storybook": "start-storybook -p 6006",

--- a/setup-test.js
+++ b/setup-test.js
@@ -1,0 +1,7 @@
+// Enzyme configuration
+import Enzyme from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+Enzyme.configure({
+  adapter: new Adapter(),
+})


### PR DESCRIPTION
## Overview

This PR updates peerDependencies to **`react@v16`** as well as updating the test toolchain. Enzyme's [migration guide](https://github.com/airbnb/enzyme/blob/master/docs/guides/migration-from-2-to-3.md) has been used and the `enzyme-adapter-react-16` package has been included in the test suite.

## How to test

- Install new packages: `npm update && npm i && npm run bootstrap`
- Run the storybook `npm run dev`