### PR TITLE
Add square Brand Icon

### DIFF
--- a/packages/fyndiq-component-brand/README.md
+++ b/packages/fyndiq-component-brand/README.md
@@ -28,6 +28,11 @@ import FyndiqLogo from 'fyndiq-component-brand'
 <FyndiqLogo>
   Fyndshopping på nätet
 </FyndiqLogo>
+
+// Square version
+import { Square } from 'fyndiq-component-brand'
+<Square />
+<Square type="outline" />
 ```
 
 # API

--- a/packages/fyndiq-component-brand/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-brand/src/__snapshots__/index.test.js.snap
@@ -126,6 +126,54 @@ exports[`fyndiq-component-brand should be rendered without props 1`] = `
 </svg>
 `;
 
+exports[`fyndiq-component-brand should exist in square version 1`] = `
+<svg
+  className="
+      type-normal
+      
+    "
+  height={56}
+  viewBox="-20 -14 56 56"
+  width={56}
+>
+  <rect
+    className="outer"
+    height="56"
+    width="56"
+    x="-20"
+    y="-14"
+  />
+  <path
+    className="inner"
+    d="M18.162 4.259c0 .321-.118.636-.32.861a1.045 1.045 0 0 1-.773.358H5.421v6.189h10.081c.287 0 .57.13.773.358.203.225.319.54.319.86v3.042c0 .32-.116.634-.32.86a1.045 1.045 0 0 1-.772.357H5.421v11.211c0 .321-.117.636-.32.861a1.047 1.047 0 0 1-.773.358H1.092c-.287 0-.569-.13-.772-.358a1.3 1.3 0 0 1-.32-.86V1.218C0 .899.117.583.32.358.523.13.805 0 1.092 0h15.977c.288 0 .57.13.773.358.202.225.32.541.32.86V4.26z"
+  />
+</svg>
+`;
+
+exports[`fyndiq-component-brand should exist in square version 2`] = `
+<svg
+  className="
+      type-outline
+      
+    "
+  height={56}
+  viewBox="-20 -14 56 56"
+  width={56}
+>
+  <rect
+    className="outer"
+    height="56"
+    width="56"
+    x="-20"
+    y="-14"
+  />
+  <path
+    className="inner"
+    d="M18.162 4.259c0 .321-.118.636-.32.861a1.045 1.045 0 0 1-.773.358H5.421v6.189h10.081c.287 0 .57.13.773.358.203.225.319.54.319.86v3.042c0 .32-.116.634-.32.86a1.045 1.045 0 0 1-.772.357H5.421v11.211c0 .321-.117.636-.32.861a1.047 1.047 0 0 1-.773.358H1.092c-.287 0-.569-.13-.772-.358a1.3 1.3 0 0 1-.32-.86V1.218C0 .899.117.583.32.358.523.13.805 0 1.092 0h15.977c.288 0 .57.13.773.358.202.225.32.541.32.86V4.26z"
+  />
+</svg>
+`;
+
 exports[`fyndiq-component-brand should have a className prop 1`] = `
 <svg
   className="

--- a/packages/fyndiq-component-brand/src/index.js
+++ b/packages/fyndiq-component-brand/src/index.js
@@ -3,7 +3,14 @@ import PropTypes from 'prop-types'
 
 import styles from '../styles.css'
 
-const FyndiqLogo = ({ className, height, width, type, children, taglineSize }) => (
+const FyndiqLogo = ({
+  className,
+  height,
+  width,
+  type,
+  children,
+  taglineSize,
+}) => (
   <svg
     // Viewbox changes if there's a tagline or not
     viewBox={children ? '-10 -1 82 36' : '-1 -1 66 28'}
@@ -55,3 +62,39 @@ FyndiqLogo.defaultProps = {
 }
 
 export default FyndiqLogo
+
+const Square = ({
+  className,
+  height,
+  width,
+  type,
+}) => (
+  <svg
+    className={`
+      ${styles['type-' + type]}
+      ${className}
+    `}
+    width={width}
+    height={height}
+    viewBox="-20 -14 56 56"
+  >
+    <rect className={styles.outer} x="-20" y="-14" width="56" height="56" />
+    <path className={styles.inner} d="M18.162 4.259c0 .321-.118.636-.32.861a1.045 1.045 0 0 1-.773.358H5.421v6.189h10.081c.287 0 .57.13.773.358.203.225.319.54.319.86v3.042c0 .32-.116.634-.32.86a1.045 1.045 0 0 1-.772.357H5.421v11.211c0 .321-.117.636-.32.861a1.047 1.047 0 0 1-.773.358H1.092c-.287 0-.569-.13-.772-.358a1.3 1.3 0 0 1-.32-.86V1.218C0 .899.117.583.32.358.523.13.805 0 1.092 0h15.977c.288 0 .57.13.773.358.202.225.32.541.32.86V4.26z" />
+  </svg>
+)
+
+Square.propTypes = {
+  className: PropTypes.string,
+  height: PropTypes.number,
+  width: PropTypes.number,
+  type: FyndiqLogo.propTypes.type,
+}
+
+Square.defaultProps = {
+  className: '',
+  height: 56,
+  width: 56,
+  type: FyndiqLogo.defaultProps.type,
+}
+
+export { Square }

--- a/packages/fyndiq-component-brand/src/index.test.js
+++ b/packages/fyndiq-component-brand/src/index.test.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import FyndiqLogo from './'
+import FyndiqLogo, { Square } from './'
 
 describe('fyndiq-component-brand', () => {
   it('should be rendered without props', () => {
@@ -26,5 +26,10 @@ describe('fyndiq-component-brand', () => {
 
   it('should have a taglineSize prop', () => {
     expect(shallow(<FyndiqLogo taglineSize={5.5}>Hello</FyndiqLogo>)).toMatchSnapshot()
+  })
+
+  it('should exist in square version', () => {
+    expect(shallow(<Square />)).toMatchSnapshot()
+    expect(shallow(<Square type="outline" />)).toMatchSnapshot()
   })
 })

--- a/packages/fyndiq-ui-test/stories/component-brand.js
+++ b/packages/fyndiq-ui-test/stories/component-brand.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import FyndiqLogo from 'fyndiq-component-brand'
+import FyndiqLogo, { Square } from 'fyndiq-component-brand'
 
 storiesOf('Icon Brand', module)
   .addWithInfo('default', () => (
@@ -36,4 +36,14 @@ storiesOf('Icon Brand', module)
     <FyndiqLogo taglineSize={5.5}>
       The Bargain Superstore
     </FyndiqLogo>
+  ))
+  .addWithInfo('square icon', () => (
+    <div style={{ background: '#eee' }}>
+      <Square />
+      <Square type="outline" />
+      <Square type="outline-transp" />
+      <Square type="bw" />
+      <Square type="outline-bw" />
+      <Square type="outline-transp-bw" />
+    </div>
   ))


### PR DESCRIPTION
## Overview

This PR adds a square version of the Brand Icon

<img width="380" alt="screen shot 2017-10-17 at 09 26 04" src="https://user-images.githubusercontent.com/1416801/31651776-3e5fdc12-b31d-11e7-9a1a-dbb2f2670a71.png">
