### PR TITLE
Remove unused color

### DIFF
--- a/packages/fyndiq-component-checkbox/styles.css
+++ b/packages/fyndiq-component-checkbox/styles.css
@@ -5,7 +5,7 @@
   border: 0;
   background: transparent;
   font-family: inherit;
-  color: var(--color-lightergrey);
+  color: var(--color-border);
   text-decoration: none;
   padding: 4px 10px;
   font-size: 12px;

--- a/packages/fyndiq-icons/star.css
+++ b/packages/fyndiq-icons/star.css
@@ -9,8 +9,8 @@
 }
 
 .greystar {
-  fill: var(--color-lightergrey);
-  stroke: var(--color-lightergrey);
+  fill: var(--color-border);
+  stroke: var(--color-border);
 }
 
 .yellowstar {


### PR DESCRIPTION
## Overview

The color `lightergrey` has been removed in **`fyndiq-ui`** #40. This PR removes the use of it across the repository.