### PR TITLE
Add emphasize prop to tweak price fontsize

### DIFF
--- a/packages/fyndiq-component-price/README.md
+++ b/packages/fyndiq-component-price/README.md
@@ -1,0 +1,40 @@
+# fyndiq-component-price [![npm](https://img.shields.io/npm/v/fyndiq-component-price.svg?maxAge=3600)](https://www.npmjs.com/package/fyndiq-component-price)
+
+[Preview](http://developers.fyndiq.com/fyndiq-ui/?selectedKind=Price&selectedStory=default)
+
+A Price Component for Fyndiq
+
+# Installation
+
+The component can be installed through NPM:
+
+``` bash
+npm i -S fyndiq-component-price
+```
+
+# Usage
+
+``` js
+import React from 'react'
+import { Price, CurrentPrice, OldPrice } from 'fyndiq-component-price'
+
+// Normal usage
+<Price>
+  <CurrentPrice>129 kr</CurrentPrice>
+  <OldPrice>200 kr</OldPrice>
+</Price>
+
+// Use same font-size
+<Price emphasize={false}>
+  <CurrentPrice>129 kr</CurrentPrice>
+  <OldPrice>200 kr</OldPrice>
+</Price>
+```
+
+# API
+
+The component `Price` has the following customizable props:
+
+| Name | Type | Description | Default value |
+|---|---|---|---|
+| **emphasize** | Boolean | Use different font-sizes for current and old price | `true` |

--- a/packages/fyndiq-component-price/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-price/src/__snapshots__/index.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CurrentPrice Component should have a default structure 1`] = `
+<span
+  className="currentPrice"
+>
+  125 kr
+</span>
+`;
+
+exports[`OldPrice Component should have a default structure 1`] = `
+<span
+  className="oldPrice"
+>
+  125 kr
+</span>
+`;
+
+exports[`Price Component should have a default structure 1`] = `
+<span
+  className="
+      price
+      emphasize
+    "
+/>
+`;
+
+exports[`Price Component should have a emphasize prop 1`] = `
+<span
+  className="
+      price
+      false
+    "
+/>
+`;

--- a/packages/fyndiq-component-price/src/index.test.js
+++ b/packages/fyndiq-component-price/src/index.test.js
@@ -1,0 +1,26 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import { Price, OldPrice, CurrentPrice } from './'
+
+describe('Price Component', () => {
+  it('should have a default structure', () => {
+    expect(shallow(<Price />)).toMatchSnapshot()
+  })
+
+  it('should have a emphasize prop', () => {
+    expect(shallow(<Price emphasize={false} />)).toMatchSnapshot()
+  })
+})
+
+describe('OldPrice Component', () => {
+  it('should have a default structure', () => {
+    expect(shallow(<OldPrice>125 kr</OldPrice>)).toMatchSnapshot()
+  })
+})
+
+describe('CurrentPrice Component', () => {
+  it('should have a default structure', () => {
+    expect(shallow(<CurrentPrice>125 kr</CurrentPrice>)).toMatchSnapshot()
+  })
+})

--- a/packages/fyndiq-component-price/src/price.js
+++ b/packages/fyndiq-component-price/src/price.js
@@ -14,11 +14,12 @@ const Price = ({ children, emphasize }) => (
 )
 
 Price.propTypes = {
-  children: PropTypes.node.isRequired,
+  children: PropTypes.node,
   emphasize: PropTypes.bool,
 }
 
 Price.defaultProps = {
+  children: null,
   emphasize: true,
 }
 

--- a/packages/fyndiq-component-price/src/price.js
+++ b/packages/fyndiq-component-price/src/price.js
@@ -2,14 +2,24 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styles from '../styles.css'
 
-const Price = ({ children }) => (
-  <span className={styles.price}>
+const Price = ({ children, emphasize }) => (
+  <span
+    className={`
+      ${styles.price}
+      ${emphasize && styles.emphasize}
+    `}
+  >
     {children}
   </span>
 )
 
 Price.propTypes = {
   children: PropTypes.node.isRequired,
+  emphasize: PropTypes.bool,
+}
+
+Price.defaultProps = {
+  emphasize: true,
 }
 
 

--- a/packages/fyndiq-component-price/styles.css
+++ b/packages/fyndiq-component-price/styles.css
@@ -8,7 +8,6 @@
 .currentPrice {
   color: var(--color-red);
   display: block;
-  font-size: 18px;
   font-weight: bold;
 }
 
@@ -16,5 +15,14 @@
   display: block;
   color: var(--color-lightgrey);
   text-decoration: line-through;
-  font-size: 11px;
+}
+
+.emphasize {
+  & .currentPrice {
+    font-size: 18px;
+  }
+
+  & .oldPrice {
+    font-size: 11px;
+  }
 }

--- a/packages/fyndiq-component-productlist/src/__snapshots__/item.test.js.snap
+++ b/packages/fyndiq-component-productlist/src/__snapshots__/item.test.js.snap
@@ -47,7 +47,9 @@ exports[`fyndiq-component-productlist ProductListItem should be displayed with m
       </div>
     </div>
     <div>
-      <Price>
+      <Price
+        emphasize={true}
+      >
         <CurrentPrice>
           price
         </CurrentPrice>
@@ -296,7 +298,9 @@ exports[`fyndiq-component-productlist ProductListItem should have an open state 
       </div>
     </div>
     <div>
-      <Price>
+      <Price
+        emphasize={true}
+      >
         <CurrentPrice>
           price
         </CurrentPrice>

--- a/packages/fyndiq-ui-test/stories/component-price.js
+++ b/packages/fyndiq-ui-test/stories/component-price.js
@@ -5,18 +5,24 @@ import { Price, OldPrice, CurrentPrice } from 'fyndiq-component-price'
 storiesOf('Price', module)
   .addWithInfo('default', () => (
     <Price>
-      <CurrentPrice>149Kr</CurrentPrice>
-      <OldPrice>200Kr</OldPrice>
+      <CurrentPrice>149 Kr</CurrentPrice>
+      <OldPrice>200 Kr</OldPrice>
     </Price>
   ))
   .addWithInfo('without old price', () => (
     <Price>
-      <CurrentPrice>149Kr</CurrentPrice>
+      <CurrentPrice>149 Kr</CurrentPrice>
     </Price>
   ))
   .addWithInfo('old price on top', () => (
     <Price>
-      <OldPrice>200Kr</OldPrice>
-      <CurrentPrice>149Kr</CurrentPrice>
+      <OldPrice>200 Kr</OldPrice>
+      <CurrentPrice>149 Kr</CurrentPrice>
+    </Price>
+  ))
+  .addWithInfo('no emphasize', () => (
+    <Price emphasize={false}>
+      <CurrentPrice>149 Kr</CurrentPrice>
+      <OldPrice>200 kr</OldPrice>
     </Price>
   ))


### PR DESCRIPTION
## Overview

This PR adds a prop that allows to stop emphasizing the font-sizes on the Price. By setting this prop to false, the user can use the parent's font-size for the prices.