### PR TITLE
Add custom close buttons to Modal

### DIFF
--- a/packages/fyndiq-component-modal/README.md
+++ b/packages/fyndiq-component-modal/README.md
@@ -18,19 +18,42 @@ The easiest way to use the `Modal` component is to open it using `ModalButton` c
 
 ``` js
 import React from 'react'
-import Modal, { ModalButton } from 'fyndiq-component-mycomponent'
+import { ModalButton } from 'fyndiq-component-mycomponent'
 
 // Normal usage
 <ModalButton button="Open Modal">
-  <Modal>
-    Modal content
-  </Modal>
+  Modal content
 </ModalButton>
 ```
 
 This setup will take care of opening the modal when pressing on the button, as well as closing the modal when clicking outside or pressing escape.
 
 For advanced use, you can use directly the `Modal` component and control its `open` prop, as well as binding the `onClose` callback prop.
+
+``` js
+import React from 'react'
+import Modal, { ModalButton } from 'fyndiq-component-mycomponent'
+
+// Advanced styling
+<ModalButton>
+  <Modal overlayClassName="overlay" wrapperClassName="wrapper">
+    Content
+  </Modal>
+</ModalButton>
+
+// Access the onClose method from the children by using a function
+<ModalButton>
+  <Modal>
+    {({ onClose }) => (
+      <div>
+        Content
+        <button onClick={onClose}>Close popup</button>
+      </div>
+    )}
+  </Modal>
+</ModalButton>
+
+```
 
 # API
 

--- a/packages/fyndiq-component-modal/src/modal.js
+++ b/packages/fyndiq-component-modal/src/modal.js
@@ -7,7 +7,7 @@ import styles from '../modal.css'
 class Modal extends React.Component {
   static propTypes = {
     open: PropTypes.bool,
-    children: PropTypes.node,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
     portalId: PropTypes.string,
     overlayClassName: PropTypes.string,
     wrapperClassName: PropTypes.string,
@@ -36,6 +36,15 @@ class Modal extends React.Component {
 
   componentWillUnmount() {
     document.removeEventListener('keypress', this.handleKeyPress)
+  }
+
+  getChildren() {
+    if (typeof this.props.children === 'function') {
+      return this.props.children({
+        onClose: this.props.onClose,
+      })
+    }
+    return this.props.children
   }
 
   handleKeyPress(e) {
@@ -75,7 +84,7 @@ class Modal extends React.Component {
             >
               &times;
             </button>
-            {this.props.children}
+            {this.getChildren()}
           </div>
         </div>
       </ModalPortal>

--- a/packages/fyndiq-component-modal/src/modal.test.js
+++ b/packages/fyndiq-component-modal/src/modal.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow, mount } from 'enzyme'
+import { shallow } from 'enzyme'
 import Modal from './modal'
 
 describe('Modal Component', () => {

--- a/packages/fyndiq-component-modal/src/modal.test.js
+++ b/packages/fyndiq-component-modal/src/modal.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { shallow } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import Modal from './modal'
 
 describe('Modal Component', () => {
@@ -58,5 +58,21 @@ describe('Modal Component', () => {
     const Component = shallow(<Modal open />)
     Component.unmount()
     expect(global.simulate.keypress).toBe(undefined)
+  })
+
+  it('should handle function children', () => {
+    const spy = jest.fn()
+    const Component = shallow(
+      <Modal open onClose={spy}>
+        {({ onClose }) => (
+          <button className="custom-close" onClick={onClose}>
+            Button
+          </button>
+        )}
+      </Modal>,
+    )
+
+    Component.find('.custom-close').simulate('click')
+    expect(spy).toHaveBeenCalled()
   })
 })

--- a/packages/fyndiq-icons/src/index.js
+++ b/packages/fyndiq-icons/src/index.js
@@ -2,5 +2,6 @@ import Arrow from './arrow'
 import Star from './star'
 import Checkmark from './checkmark'
 import Magnifier from './magnifier'
+import Pencil from './pencil'
 
-export { Arrow, Star, Checkmark, Magnifier }
+export { Arrow, Star, Checkmark, Magnifier, Pencil }

--- a/packages/fyndiq-icons/src/pencil.js
+++ b/packages/fyndiq-icons/src/pencil.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import colors from 'fyndiq-styles-colors'
+
+const Pencil = ({ className }) => (
+  <svg className={className} viewBox="0 0 14 14">
+    <defs>
+      <path id="a" d="M9.54.82h2.82v2.82H9.54V.82z" />
+    </defs>
+    <g fill="none" fillRule="evenodd">
+      <path
+        fill={colors.black}
+        d="M1 12.28v.9h1.8l-.9-.9-.9-.9M1 11.37l1.8 1.8.45-.43-1.8-1.8M11.13 1.06l-.6.6 2 1.98.6-.58c.3-.32.3-.85 0-1.17l-.84-.84c-.33-.32-.85-.32-1.17 0"
+      />
+      <path
+        stroke={colors.black}
+        d="M10.48 2.46L1.43 11.5M11.7 3.7l-9.04 9.04"
+      />
+    </g>
+  </svg>
+)
+
+Pencil.propTypes = {
+  className: PropTypes.string,
+}
+
+Pencil.defaultProps = {
+  className: '',
+}
+
+export default Pencil

--- a/packages/fyndiq-ui-test/stories/component-modal.js
+++ b/packages/fyndiq-ui-test/stories/component-modal.js
@@ -22,3 +22,10 @@ storiesOf('Modal', module)
       Content
     </ModalButton>
   ))
+  .addWithInfo('custom close button', () => (
+    <ModalButton>
+      <Modal>
+        {({ onClose }) => <button onClick={onClose}>Close modal</button>}
+      </Modal>
+    </ModalButton>
+  ))


### PR DESCRIPTION
## Overview

This PR adds the ability to add custom close buttons to a Modal

It works like this: if the prop `children` is a function, it will be passed the `onClose` callback as argument:

``` js
import Modal from 'fyndiq-component-modal'

<Modal>
  {({ onClose }) => (
    <button onClick={onClose}>Close</button>
  )}
</Modal>
```