### PR TITLE
Add Component message

### DIFF
--- a/packages/fyndiq-component-button/styles.css
+++ b/packages/fyndiq-component-button/styles.css
@@ -7,6 +7,7 @@
   color: var(--color-black);
   font-family: inherit;
   text-decoration: none;
+  margin: 0;
 }
 
 .button:focus {
@@ -145,7 +146,7 @@
 
   /* Remove borders and fix border-radiuses */
   & .button + .button {
-    border-left: none;
+    border-left: 0;
   }
 
   & :first-child:not(:last-child) {
@@ -165,16 +166,16 @@
   /* No Outer Border */
   &.wrapperNoOuterBorder {
     & .button {
-      border-top: none;
-      border-bottom: none;
+      border-top: 0;
+      border-bottom: 0;
     }
 
     & :first-child {
-      border-left: none;
+      border-left: 0;
     }
 
     & :last-child {
-      border-right: none;
+      border-right: 0;
     }
   }
 }
@@ -184,7 +185,7 @@
 
   /* Remove borders and fix border-radiuses */
   & .button + .button {
-    border-top: none;
+    border-top: 0;
   }
 
   & :first-child:not(:last-child) {
@@ -204,16 +205,16 @@
   /* No Outer Border */
   &.wrapperNoOuterBorder {
     & .button {
-      border-right: none;
-      border-left: none;
+      border-right: 0;
+      border-left: 0;
     }
 
     & :first-child {
-      border-top: none;
+      border-top: 0;
     }
 
     & :last-child {
-      border-bottom: none;
+      border-bottom: 0;
     }
   }
 }

--- a/packages/fyndiq-component-dropdown/styles.css
+++ b/packages/fyndiq-component-dropdown/styles.css
@@ -1,7 +1,7 @@
 @import "fyndiq-styles-colors/colors.css";
 
 .wrapper {
-  display: inline-block;
+  display: inline-flex;
   position: relative;
 }
 

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -3,10 +3,12 @@
 .input {
   padding: 0 20px;
   background: var(--color-white);
+  margin: 0;
   border: 1px solid var(--color-border);
   border-radius: 2px;
   font-size: 15px;
   line-height: 48px;
+  outline: 0;
 
   &:invalid {
     box-shadow: none;
@@ -30,7 +32,6 @@
     border-left: 0;
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
-    height: 100%;
   }
 }
 
@@ -64,6 +65,7 @@
 .invisibleInput {
   font-weight: inherit;
   font-size: inherit;
+  margin: 0;
   color: inherit;
   border: 1px solid transparent;
   border-top-left-radius: 2px;

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -9,6 +9,7 @@
   font-size: 15px;
   line-height: 48px;
   outline: 0;
+  appearance: none;
 
   &:invalid {
     box-shadow: none;
@@ -79,6 +80,7 @@
   display: flex;
   align-items: center;
   padding: 2px 4px;
+  margin: 0;
   border: 1px solid transparent;
   border-left: none;
   background: transparent;

--- a/packages/fyndiq-component-input/search.css
+++ b/packages/fyndiq-component-input/search.css
@@ -34,6 +34,7 @@
   width: 0;
   transition: .15s ease-out;
   background: transparent;
+  outline: 0;
 }
 
 .wrapperOpen {

--- a/packages/fyndiq-component-message/message.css
+++ b/packages/fyndiq-component-message/message.css
@@ -1,5 +1,17 @@
 @import "fyndiq-styles-colors/colors.css";
 
+.wrapper {
+  position: fixed;
+  top: 60px;
+  width: 100%;
+  text-align: center;
+  pointer-events: none;
+
+  & .message {
+    pointer-events: all;
+  }
+}
+
 .message {
   display: inline-flex;
   align-items: center;

--- a/packages/fyndiq-component-message/message.css
+++ b/packages/fyndiq-component-message/message.css
@@ -1,0 +1,36 @@
+@import "fyndiq-styles-colors/colors.css";
+
+.message {
+  display: inline-flex;
+  align-items: center;
+  padding: 9px 20px;
+  background: var(--color-white);
+  box-shadow: 0 0 5px 0 color(var(--color-black) a(30%));
+  border-radius: 2px;
+  margin-bottom: 8px;
+
+  & svg {
+    display: inline-block;
+    position: relative;
+    left: -5px;
+    width: 16px;
+    max-height: 16px;
+    margin-right: 8px;
+  }
+}
+
+.message--type_info {
+  border: 1px solid var(--color-blue);
+}
+
+.message--type_confirm {
+  border: 1px solid var(--color-green);
+}
+
+.message--type_warn {
+  border: 1px solid var(--color-orange);
+}
+
+.message--type_error {
+  border: 1px solid var(--color-red);
+}

--- a/packages/fyndiq-component-message/package.json
+++ b/packages/fyndiq-component-message/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "fyndiq-component-message",
+  "version": "2.0.0",
+  "author": "Thibaut Remy <thibaut.remy@fyndiq.com>",
+  "main": "lib/index.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fyndiq/fyndiq-ui.git"
+  },
+  "homepage": "http://developers.fyndiq.com/fyndiq-ui/?selectedKind=Message&selectedStory=default",
+  "dependencies": {
+    "fyndiq-styles-colors": "*"
+  },
+  "peerDependencies": {
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.0.0",
+    "react": "^15.0.0 || ^16.0.0"
+  }
+}

--- a/packages/fyndiq-component-message/package.json
+++ b/packages/fyndiq-component-message/package.json
@@ -18,6 +18,7 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.6",
     "prop-types": "^15.0.0",
-    "react": "^15.0.0 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   }
 }

--- a/packages/fyndiq-component-message/src/__snapshots__/message-portal.test.js.snap
+++ b/packages/fyndiq-component-message/src/__snapshots__/message-portal.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fyndiq-component-message MessagePortal should return a Portal 1`] = `"Content"`;

--- a/packages/fyndiq-component-message/src/__snapshots__/message-wrapper.test.js.snap
+++ b/packages/fyndiq-component-message/src/__snapshots__/message-wrapper.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fyndiq-component-message MessageWrapper static addMessage should have the proper structure 1`] = `
+<MessagePortal
+  portalId="fyndiq-message-portal"
+>
+  <div
+    className="wrapper"
+  >
+    <div
+      key="RANDOM-ID"
+    >
+      <Message
+        icon={null}
+        id="RANDOM-ID"
+        onClose={[Function]}
+        timeout={5000}
+        type="info"
+      >
+        New message 1
+      </Message>
+    </div>
+    <div
+      key="RANDOM-ID"
+    >
+      <Message
+        icon={null}
+        id="RANDOM-ID"
+        onClose={[Function]}
+        timeout={5000}
+        type="info"
+      >
+        New message 2
+      </Message>
+    </div>
+  </div>
+</MessagePortal>
+`;

--- a/packages/fyndiq-component-message/src/__snapshots__/message.test.js.snap
+++ b/packages/fyndiq-component-message/src/__snapshots__/message.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fyndiq-component-message Message should have the proper structure 1`] = `
+<div
+  className="
+          message
+          message--type_info
+        "
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+>
+  <svg
+    color="#4A90E2"
+  >
+    Icon
+  </svg>
+  Message
+</div>
+`;

--- a/packages/fyndiq-component-message/src/add-message.js
+++ b/packages/fyndiq-component-message/src/add-message.js
@@ -1,0 +1,5 @@
+import Wrapper from './message-wrapper'
+
+const { addMessage } = Wrapper
+
+export default addMessage

--- a/packages/fyndiq-component-message/src/index.js
+++ b/packages/fyndiq-component-message/src/index.js
@@ -1,0 +1,3 @@
+import Message from './message'
+
+export { Message }

--- a/packages/fyndiq-component-message/src/index.js
+++ b/packages/fyndiq-component-message/src/index.js
@@ -1,3 +1,5 @@
 import Message from './message'
+import Wrapper from './message-wrapper'
+import addMessage from './add-message'
 
-export { Message }
+export { Message, Wrapper, addMessage }

--- a/packages/fyndiq-component-message/src/message-portal.js
+++ b/packages/fyndiq-component-message/src/message-portal.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import PropTypes from 'prop-types'
+
+// This component creates a Portal helper
+// for the Message Component. It is not intended
+// to be used directly
+class MessagePortal extends React.Component {
+  static propTypes = {
+    portalId: PropTypes.string,
+    children: PropTypes.node,
+  }
+
+  static defaultProps = {
+    children: null,
+    portalId: 'fyndiq-message-portal',
+  }
+
+  componentWillMount() {
+    // Create portal element if it doesn't exist
+    if (!document.getElementById(this.props.portalId)) {
+      const portalDiv = document.createElement('div')
+      portalDiv.id = this.props.portalId
+      document.body.appendChild(portalDiv)
+    }
+  }
+
+  render() {
+    return ReactDOM.createPortal(
+      this.props.children,
+      document.getElementById(this.props.portalId),
+    )
+  }
+}
+
+export default MessagePortal

--- a/packages/fyndiq-component-message/src/message-portal.test.js
+++ b/packages/fyndiq-component-message/src/message-portal.test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { shallow } from 'enzyme'
+import MessagePortal from './message-portal'
+
+describe('fyndiq-component-message MessagePortal', () => {
+  it('should return a Portal', () => {
+    // Mock the Portal behavior to return its content
+    ReactDOM.createPortal = jest.fn(children => children)
+    const Component = shallow(<MessagePortal>Content</MessagePortal>)
+    expect(Component).toMatchSnapshot()
+  })
+
+  it('should create a portal div on mount', () => {
+    shallow(<MessagePortal portalId="test-id" />)
+    expect(document.getElementById('test-id')).not.toBe(null)
+  })
+
+  it('should not create another portal with the same ID', () => {
+    shallow(<MessagePortal portalId="test-id" />)
+    shallow(<MessagePortal portalId="test-id" />)
+    expect(document.querySelectorAll('#test-id').length).toBe(1)
+  })
+})

--- a/packages/fyndiq-component-message/src/message-wrapper.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.js
@@ -1,0 +1,84 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import MessagePortal from './message-portal'
+import styles from '../message.css'
+
+class MessageWrapper extends React.Component {
+  static propTypes = {
+    messages: PropTypes.arrayOf(PropTypes.element),
+  }
+
+  static defaultProps = {
+    messages: [],
+  }
+
+  // Keep only one instance of MessageWrapper
+  static instance = null
+
+  static addMessage(message) {
+    if (MessageWrapper.instance == null) {
+      throw new Error('MessageWrapper has no instance running')
+    }
+
+    MessageWrapper.instance.addMessage(message)
+  }
+
+  constructor(props) {
+    super(props)
+
+    this.state = { messages: this.props.messages }
+
+    this.addMessage = this.addMessage.bind(this)
+  }
+
+  componentWillMount() {
+    if (MessageWrapper.instance != null) {
+      console.warn('MessageWrapper already had an instance')
+    }
+
+    MessageWrapper.instance = this
+  }
+
+  componentWillUnmount() {
+    MessageWrapper.instance = null
+  }
+
+  addMessage(message) {
+    this.setState(state => ({
+      messages: [...state.messages, message],
+    }))
+  }
+
+  removeMessage(message) {
+    this.setState(state => {
+      const index = state.messages.indexOf(message)
+
+      return {
+        ...state,
+        messages: [
+          ...state.messages.slice(0, index),
+          ...state.messages.slice(index + 1),
+        ],
+      }
+    })
+  }
+
+  render() {
+    return (
+      <MessagePortal>
+        <div className={styles.wrapper}>
+          {this.state.messages.map((message, id) => (
+            <div key={id}>
+              {React.cloneElement(message, {
+                onClose: () => this.removeMessage(message),
+              })}
+            </div>
+          ))}
+        </div>
+      </MessagePortal>
+    )
+  }
+}
+
+export default MessageWrapper

--- a/packages/fyndiq-component-message/src/message-wrapper.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.js
@@ -37,7 +37,10 @@ class MessageWrapper extends React.Component {
 
   addMessage(message) {
     this.setState(state => ({
-      messages: [...state.messages, message],
+      messages: [
+        ...state.messages,
+        React.cloneElement(message, { id: Math.random() }),
+      ],
     }))
   }
 
@@ -59,8 +62,8 @@ class MessageWrapper extends React.Component {
     return (
       <MessagePortal>
         <div className={styles.wrapper}>
-          {this.state.messages.map((message, id) => (
-            <div key={id}>
+          {this.state.messages.map(message => (
+            <div key={message.props.id}>
               {React.cloneElement(message, {
                 onClose: () => this.removeMessage(message),
               })}

--- a/packages/fyndiq-component-message/src/message-wrapper.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.js
@@ -1,18 +1,9 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 
 import MessagePortal from './message-portal'
 import styles from '../message.css'
 
 class MessageWrapper extends React.Component {
-  static propTypes = {
-    messages: PropTypes.arrayOf(PropTypes.element),
-  }
-
-  static defaultProps = {
-    messages: [],
-  }
-
   // Keep only one instance of MessageWrapper
   static instance = null
 
@@ -27,7 +18,7 @@ class MessageWrapper extends React.Component {
   constructor(props) {
     super(props)
 
-    this.state = { messages: this.props.messages }
+    this.state = { messages: [] }
 
     this.addMessage = this.addMessage.bind(this)
   }

--- a/packages/fyndiq-component-message/src/message-wrapper.test.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.test.js
@@ -1,0 +1,54 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Message from './message'
+import Wrapper from './message-wrapper'
+
+describe('fyndiq-component-message MessageWrapper', () => {
+  beforeEach(() => {
+    Wrapper.instance = null
+  })
+
+  it('should keep an instance of the running wrapper', () => {
+    shallow(<Wrapper />)
+    expect(Wrapper.instance).not.toBe(null)
+  })
+
+  it('should warn the user if there are 2 instances of wrapper', () => {
+    console.warn = jest.fn()
+    shallow(<Wrapper />)
+    shallow(<Wrapper />)
+    expect(console.warn).toHaveBeenCalled()
+  })
+
+  it('should remove messages internally', () => {
+    const component = shallow(<Wrapper />)
+    Wrapper.addMessage(<Message>New message</Message>)
+    component.update()
+    component.find(Message).simulate('close')
+    component.update()
+    expect(component.find(Message).exists()).toBe(false)
+  })
+
+  describe('static addMessage', () => {
+    it('should have a static addMessage function', () => {
+      const component = shallow(<Wrapper />)
+      Wrapper.addMessage(<Message>New message</Message>)
+      component.update()
+      expect(component.find(Message).exists()).toBe(true)
+    })
+
+    it('should throw if there is no instance of Wrapper', () => {
+      expect(() => Wrapper.addMessage(<Message>New message</Message>)).toThrow()
+    })
+
+    it('should have the proper structure', () => {
+      Math.random = jest.fn(() => 'RANDOM-ID')
+      const component = shallow(<Wrapper />)
+      Wrapper.addMessage(<Message>New message 1</Message>)
+      Wrapper.addMessage(<Message>New message 2</Message>)
+      component.update()
+      expect(component).toMatchSnapshot()
+    })
+  })
+})

--- a/packages/fyndiq-component-message/src/message.js
+++ b/packages/fyndiq-component-message/src/message.js
@@ -41,14 +41,14 @@ class Message extends React.Component {
 
   pause() {
     clearTimeout(this.timeout)
-    this.remaining -= new Date() - this.start
+    this.remaining -= Date.now() - this.start
 
     // Timer should be at least 1s
     this.remaining = Math.max(this.remaining, 1000)
   }
 
   resume() {
-    this.start = new Date()
+    this.start = Date.now()
     clearTimeout(this.timeout)
     this.timeout = setTimeout(this.props.onClose, this.remaining)
   }

--- a/packages/fyndiq-component-message/src/message.js
+++ b/packages/fyndiq-component-message/src/message.js
@@ -11,28 +11,81 @@ const colors = {
   error: fyndiqColors.red,
 }
 
-const Message = ({ type, children, icon }) => (
-  <div
-    className={`
-      ${styles.message}
-      ${styles[`message--type_${type}`]}
-    `}
-  >
-    {icon && React.cloneElement(icon, { color: colors[type] })}
-    {children}
-  </div>
-)
+class Message extends React.Component {
+  constructor(props) {
+    super(props)
+
+    this.remaining = this.props.timeout
+
+    this.onMouseEnter = this.onMouseEnter.bind(this)
+    this.onMouseLeave = this.onMouseLeave.bind(this)
+  }
+
+  componentWillMount() {
+    this.resume()
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.timeout)
+  }
+
+  onMouseEnter() {
+    // Pause the timer
+    this.pause()
+  }
+
+  onMouseLeave() {
+    // Resume the timer
+    this.resume()
+  }
+
+  pause() {
+    clearTimeout(this.timeout)
+    this.remaining -= new Date() - this.start
+
+    // Timer should be at least 1s
+    this.remaining = Math.max(this.remaining, 1000)
+  }
+
+  resume() {
+    this.start = new Date()
+    clearTimeout(this.timeout)
+    this.timeout = setTimeout(this.props.onClose, this.remaining)
+  }
+
+  render() {
+    const { type, children, icon } = this.props
+
+    return (
+      <div
+        className={`
+          ${styles.message}
+          ${styles[`message--type_${type}`]}
+        `}
+        onMouseEnter={this.onMouseEnter}
+        onMouseLeave={this.onMouseLeave}
+      >
+        {icon && React.cloneElement(icon, { color: colors[type] })}
+        {children}
+      </div>
+    )
+  }
+}
 
 Message.propTypes = {
   type: PropTypes.oneOf(['info', 'confirm', 'warn', 'error']),
   children: PropTypes.node,
   icon: PropTypes.element,
+  onClose: PropTypes.func,
+  timeout: PropTypes.number,
 }
 
 Message.defaultProps = {
   type: 'info',
   children: null,
   icon: null,
+  onClose: () => {},
+  timeout: 5000,
 }
 
 export default Message

--- a/packages/fyndiq-component-message/src/message.js
+++ b/packages/fyndiq-component-message/src/message.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import fyndiqColors from 'fyndiq-styles-colors'
+
+import styles from '../message.css'
+
+const colors = {
+  info: fyndiqColors.blue,
+  confirm: fyndiqColors.green,
+  warn: fyndiqColors.orange,
+  error: fyndiqColors.red,
+}
+
+const Message = ({ type, children, icon }) => (
+  <div
+    className={`
+      ${styles.message}
+      ${styles[`message--type_${type}`]}
+    `}
+  >
+    {icon && React.cloneElement(icon, { color: colors[type] })}
+    {children}
+  </div>
+)
+
+Message.propTypes = {
+  type: PropTypes.oneOf(['info', 'confirm', 'warn', 'error']),
+  children: PropTypes.node,
+  icon: PropTypes.element,
+}
+
+Message.defaultProps = {
+  type: 'info',
+  children: null,
+  icon: null,
+}
+
+export default Message

--- a/packages/fyndiq-component-message/src/message.test.js
+++ b/packages/fyndiq-component-message/src/message.test.js
@@ -1,0 +1,90 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import Message from './message'
+
+// eslint-disable-next-line react/prop-types
+const Icon = ({ color }) => <span>Icon {color}</span>
+
+describe('fyndiq-component-message Message', () => {
+  it('should have the proper structure', () => {
+    expect(
+      shallow(<Message icon={<svg>Icon</svg>}>Message</Message>),
+    ).toMatchSnapshot()
+  })
+
+  it('should have a type prop', () => {
+    const component = shallow(
+      <Message icon={<Icon />} type="confirm">
+        Message
+      </Message>,
+    )
+
+    expect(component.hasClass('message--type_confirm')).toBe(true)
+    expect(component.find(Icon).prop('color')).not.toBe(undefined)
+  })
+
+  it('should call onClose after <timeout>ms', () => {
+    jest.useFakeTimers()
+    const spy = jest.fn()
+    shallow(
+      <Message timeout={3000} onClose={spy}>
+        Message
+      </Message>,
+    )
+    jest.runTimersToTime(3000)
+    expect(spy).toHaveBeenCalled()
+  })
+
+  describe('timeout', () => {
+    it('should pause the timeout if the message is hovered', () => {
+      jest.useFakeTimers()
+      const spy = jest.fn()
+      const component = shallow(
+        <Message timeout={3000} onClose={spy}>
+          Message
+        </Message>,
+      )
+
+      jest.runTimersToTime(1200)
+      component.simulate('mouseenter')
+      jest.runTimersToTime(3000)
+      expect(spy).not.toHaveBeenCalled()
+    })
+
+    it('should restart the timeout when the message is left', () => {
+      jest.useFakeTimers()
+      const spy = jest.fn()
+      // Mock Date.now : it needs to follow jest.runTimersToTime()
+      Date.now = () => 0
+      const component = shallow(
+        <Message timeout={3000} onClose={spy}>
+          Message
+        </Message>,
+      )
+
+      jest.runTimersToTime(1200)
+      Date.now = () => 1200
+      component.simulate('mouseenter')
+      jest.runTimersToTime(3000)
+      Date.now = () => 4200
+      component.simulate('mouseleave')
+      jest.runTimersToTime(2800)
+      Date.now = () => 6000
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('should cancel the timeout when the component unmounts', () => {
+      jest.useFakeTimers()
+      const spy = jest.fn()
+      const component = shallow(
+        <Message timeout={3000} onClose={spy}>
+          Message
+        </Message>,
+      )
+      component.unmount()
+      jest.runTimersToTime(3000)
+      expect(spy).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/packages/fyndiq-icons/src/error.js
+++ b/packages/fyndiq-icons/src/error.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import colors from 'fyndiq-styles-colors'
+
+const Error = ({ className, color }) => (
+  <svg className={className} viewBox="0 0 20 20">
+    <path
+      stroke={color}
+      fill="none"
+      d="M5.67 5.67l8.66 8.66m-8.66 0l8.66-8.66"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      stroke={color}
+      fill="none"
+      d="M19.07 10A9.07 9.07 0 1 1 .93 10a9.07 9.07 0 0 1 18.14 0z"
+    />
+  </svg>
+)
+
+Error.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.string,
+}
+
+Error.defaultProps = {
+  className: '',
+  color: colors.black,
+}
+
+export default Error

--- a/packages/fyndiq-icons/src/index.js
+++ b/packages/fyndiq-icons/src/index.js
@@ -4,8 +4,20 @@ import Checkmark from './checkmark'
 import Error from './error'
 import Magnifier from './magnifier'
 import Pencil from './pencil'
+import Shop from './shop'
 import Star from './star'
 import Truck from './truck'
 import Warning from './warning'
 
-export { Arrow, Bag, Checkmark, Error, Magnifier, Pencil, Star, Truck, Warning }
+export {
+  Arrow,
+  Bag,
+  Checkmark,
+  Error,
+  Magnifier,
+  Pencil,
+  Shop,
+  Star,
+  Truck,
+  Warning,
+}

--- a/packages/fyndiq-icons/src/index.js
+++ b/packages/fyndiq-icons/src/index.js
@@ -1,8 +1,11 @@
 import Arrow from './arrow'
 import Bag from './bag'
-import Star from './star'
 import Checkmark from './checkmark'
+import Error from './error'
 import Magnifier from './magnifier'
 import Pencil from './pencil'
+import Star from './star'
+import Truck from './truck'
+import Warning from './warning'
 
-export { Arrow, Bag, Star, Checkmark, Magnifier, Pencil }
+export { Arrow, Bag, Checkmark, Error, Magnifier, Pencil, Star, Truck, Warning }

--- a/packages/fyndiq-icons/src/shop.js
+++ b/packages/fyndiq-icons/src/shop.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import colors from 'fyndiq-styles-colors'
+
+const Shop = ({ className, color }) => (
+  <svg className={className} viewBox="0 0 20 18">
+    <path
+      stroke={color}
+      fill="none"
+      d="M18.3 17V8.5M1.3 17V8.5m.22 7H17.8m-16.28-3H17.8"
+      strokeLinecap="round"
+    />
+    <path
+      stroke={color}
+      fill="none"
+      d="M8 7c0 .83-.82 1.5-1.8 1.5S4.4 7.83 4.4 7V2.5M11.6 7c0 .83-.82 1.5-1.8 1.5C8.8 8.5 8 7.83 8 7V2.5"
+    />
+    <path
+      stroke={color}
+      fill="none"
+      d="M15.2 7c0 .83-.82 1.5-1.8 1.5-1 0-1.8-.67-1.8-1.5V2.5"
+    />
+    <path
+      stroke={color}
+      fill="none"
+      d="M15.2 2.5V7c0 .83.8 1.5 1.8 1.5.98 0 1.8-.67 1.8-1.5V2.5H.8V7c0 .83.8 1.5 1.8 1.5.98 0 1.8-.67 1.8-1.5m14.4-4.5v-2H.8v2"
+    />
+  </svg>
+)
+
+Shop.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.string,
+}
+
+Shop.defaultProps = {
+  className: '',
+  color: colors.black,
+}
+
+export default Shop

--- a/packages/fyndiq-icons/src/truck.js
+++ b/packages/fyndiq-icons/src/truck.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import colors from 'fyndiq-styles-colors'
+
+const Truck = ({ className, color }) => (
+  <svg className={className} viewBox="0 0 19 14">
+    <path
+      stroke={color}
+      fill="none"
+      d="M.5 11.5h10V.5H.5z"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      stroke={color}
+      fill="none"
+      d="M11 2.5h3.8c.2 0 .4.12.5.3l2.05 3.66c.1.18.15.4.15.6v3.85c0 .34-.26.6-.6.6H5.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path fill={color} d="M12.5 4.03V7h3.25l-1.47-2.97z" />
+    <path
+      fill="#FFF"
+      stroke={color}
+      d="M16 11.5a2 2 0 1 1-4 0 2 2 0 0 1 4 0zm-10 0a2 2 0 1 1-4 0 2 2 0 0 1 4 0z"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+Truck.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.string,
+}
+
+Truck.defaultProps = {
+  className: '',
+  color: colors.black,
+}
+
+export default Truck

--- a/packages/fyndiq-icons/src/warning.js
+++ b/packages/fyndiq-icons/src/warning.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import colors from 'fyndiq-styles-colors'
+
+const Warning = ({ className, color }) => (
+  <svg className={className} viewBox="0 0 19 16">
+    <path
+      fill="none"
+      stroke={color}
+      d="M7.88 1.4a1.9 1.9 0 0 1 3.24 0l3.68 5.78 3.4 5.32c.8 1.3-.1 3-1.63 3H2.43C.9 15.5 0 13.8.8 12.5l3.4-5.33L7.88 1.4z"
+      strokeLinejoin="round"
+    />
+    <path
+      fill="none"
+      stroke={color}
+      d="M9.5 9.5A.5.5 0 0 1 9 9V5c0-.26.23-.5.5-.5s.5.24.5.5v4c0 .3-.23.5-.5.5z"
+    />
+    <path fill={color} d="M10.5 12.22a1 1 0 1 1-2 0 1 1 0 0 1 2 0" />
+  </svg>
+)
+
+Warning.propTypes = {
+  className: PropTypes.string,
+  color: PropTypes.string,
+}
+
+Warning.defaultProps = {
+  className: '',
+  color: colors.black,
+}
+
+export default Warning

--- a/packages/fyndiq-ui-test/.storybook/config.js
+++ b/packages/fyndiq-ui-test/.storybook/config.js
@@ -4,6 +4,7 @@ import infoAddon from '@storybook/addon-info'
 // Bootstrap standard fonts
 
 import 'fyndiq-styles-fonts/bootstrap.css'
+import './fyndiq-reset.css'
 
 function loadStories() {
   /* eslint-disable global-require */

--- a/packages/fyndiq-ui-test/.storybook/config.js
+++ b/packages/fyndiq-ui-test/.storybook/config.js
@@ -14,6 +14,7 @@ function loadStories() {
   require('../stories/component-checkbox')
   require('../stories/component-input')
   require('../stories/component-stars')
+  require('../stories/component-message')
   require('../stories/component-modal')
   require('../stories/component-price')
   require('../stories/component-productcard')

--- a/packages/fyndiq-ui-test/.storybook/fyndiq-reset.css
+++ b/packages/fyndiq-ui-test/.storybook/fyndiq-reset.css
@@ -1,0 +1,5 @@
+@import "fyndiq-styles-colors/colors.css";
+
+html {
+  color: var(--color-black);
+}

--- a/packages/fyndiq-ui-test/package.json
+++ b/packages/fyndiq-ui-test/package.json
@@ -13,6 +13,7 @@
     "fyndiq-component-input": "^2.1.0",
     "fyndiq-component-loader": "^2.1.3",
     "fyndiq-component-modal": "^2.3.2",
+    "fyndiq-component-message": "*",
     "fyndiq-component-price": "^2.3.2",
     "fyndiq-component-productcard": "^2.1.8",
     "fyndiq-component-productlist": "^2.1.8",
@@ -20,6 +21,7 @@
     "fyndiq-component-table": "^2.1.0",
     "fyndiq-component-tooltip": "^2.3.2",
     "fyndiq-illustrations": "^2.0.4",
+    "fyndiq-icons": "*",
     "fyndiq-styles-colors": "*",
     "fyndiq-styles-fonts": "^2.1.0"
   },

--- a/packages/fyndiq-ui-test/stories/component-message.js
+++ b/packages/fyndiq-ui-test/stories/component-message.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { Message } from 'fyndiq-component-message'
+import { Error, Truck, Warning } from 'fyndiq-icons'
+
+storiesOf('Message', module)
+  .addWithInfo('default', () => <Message>Content</Message>)
+  .addWithInfo('color themes', () => (
+    <div>
+      <div>
+        <Message icon={<Truck />}>Type info</Message>
+      </div>
+      <div>
+        <Message icon={<Truck />} type="confirm">
+          Type confirm
+        </Message>
+      </div>
+      <div>
+        <Message icon={<Warning />} type="warn">
+          Type warn
+        </Message>
+      </div>
+      <div>
+        <Message icon={<Error />} type="error">
+          Type error
+        </Message>
+      </div>
+    </div>
+  ))

--- a/packages/fyndiq-ui-test/stories/component-message.js
+++ b/packages/fyndiq-ui-test/stories/component-message.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
-import { Message } from 'fyndiq-component-message'
+import Button from 'fyndiq-component-button'
+import { Message, Wrapper, addMessage } from 'fyndiq-component-message'
 import { Error, Truck, Warning } from 'fyndiq-icons'
 
 storiesOf('Message', module)
@@ -25,5 +26,20 @@ storiesOf('Message', module)
           Type error
         </Message>
       </div>
+    </div>
+  ))
+  .addWithInfo('action', () => (
+    <div>
+      <Wrapper />
+      <Button
+        onClick={() =>
+          addMessage(
+            <Message icon={<Truck />} type="confirm">
+              Type confirm {Math.random()}
+            </Message>,
+          )}
+      >
+        Show message
+      </Button>
     </div>
   ))


### PR DESCRIPTION
## Overview

This PR adds a Message component, as well as fixing some issues in different packages

### `fyndiq-icons`

:new: Adds 4 Icons: Truck, Warning, Error, Shop.

### `fyndiq-component-message`

:new: Add Message, Wrapper components
:new: Add `createMessage` utility function

### Other changes

- Improve cross-browser design for the following components: Button, Input, Presets, Dropdown.