### PR TITLE
Don't use CSS for table display

### DIFF
--- a/packages/fyndiq-component-table/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-table/src/__snapshots__/index.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`fyndiq-component-table Cell component should have the right structure 1`] = `
-<div
+<td
   className="
       cell
       false
@@ -9,11 +9,11 @@ exports[`fyndiq-component-table Cell component should have the right structure 1
     "
 >
   Content
-</div>
+</td>
 `;
 
 exports[`fyndiq-component-table Row component should have the right structure 1`] = `
-<div
+<tr
   className="
       row
       false
@@ -25,16 +25,16 @@ exports[`fyndiq-component-table Row component should have the right structure 1`
     "
 >
   Content
-</div>
+</tr>
 `;
 
 exports[`fyndiq-component-table Table component should have the right structure 1`] = `
-<div
+<table
   className="
       table
       className
     "
 >
   Content
-</div>
+</table>
 `;

--- a/packages/fyndiq-component-table/src/cell.js
+++ b/packages/fyndiq-component-table/src/cell.js
@@ -3,16 +3,17 @@ import PropTypes from 'prop-types'
 
 import styles from '../table.css'
 
-const Cell = ({ children, className, center }) => (
-  <div
+const Cell = ({ children, className, center, ...props }) => (
+  <td
     className={`
       ${styles.cell}
       ${center && styles.cellCenter}
       ${className}
     `}
+    {...props}
   >
     {children}
-  </div>
+  </td>
 )
 
 Cell.propTypes = {

--- a/packages/fyndiq-component-table/src/row.js
+++ b/packages/fyndiq-component-table/src/row.js
@@ -11,8 +11,9 @@ const Row = ({
   noBorder,
   size,
   verticalCenter,
+  ...props
 }) => (
-  <div
+  <tr
     className={`
       ${styles.row}
       ${head && styles.rowHead}
@@ -22,9 +23,10 @@ const Row = ({
       ${styles[`rowSize-${size}`]}
       ${className}
     `}
+    {...props}
   >
     {children}
-  </div>
+  </tr>
 )
 
 Row.propTypes = {

--- a/packages/fyndiq-component-table/src/table.js
+++ b/packages/fyndiq-component-table/src/table.js
@@ -3,15 +3,16 @@ import PropTypes from 'prop-types'
 
 import styles from '../table.css'
 
-const Table = ({ children, className }) => (
-  <div
+const Table = ({ children, className, ...props }) => (
+  <table
     className={`
       ${styles.table}
       ${className}
     `}
+    {...props}
   >
     {children}
-  </div>
+  </table>
 )
 
 Table.propTypes = {

--- a/packages/fyndiq-component-table/table.css
+++ b/packages/fyndiq-component-table/table.css
@@ -1,14 +1,11 @@
 @import "fyndiq-styles-colors/colors.css";
 
 .table {
-  display: table;
   border-collapse: collapse;
   width: 100%;
 }
 
 .row {
-  display: table-row;
-
   &:not(.rowNoBorder) {
     border-bottom: 1px solid var(--color-border);
   }
@@ -53,7 +50,6 @@
 }
 
 .cell {
-  display: table-cell;
   padding: 0 8px;
 }
 


### PR DESCRIPTION
CSS tables can't have colspan which is a big blocker, so using `<table>`, `<tr>` and `<td>` elements