### PR TITLE
Add Component layout and update component-table

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "postcss-import": "^11.0.0",
     "postcss-loader": "^2.0.10",
     "prop-types": "^15.6.0",
+    "react-router-dom": "^4.2.2",
     "style-loader": "^0.19.0",
     "stylelint": "^8.4.0",
     "stylelint-config-standard": "^18.0.0"

--- a/packages/fyndiq-component-article/article.css
+++ b/packages/fyndiq-component-article/article.css
@@ -11,10 +11,11 @@
 
 .tag {
   display: inline-block;
-  padding: 2px 8px;
-  margin-right: 5px;
-  font-size: 11px;
-  border-radius: 100px;
+  padding: 4px 8px;
+  margin: 0 5px 5px 0;
+  font-size: 12px;
+  border-radius: 2px;
   color: var(--color-white);
-  background-color: var(--color-black);
+  background-color: var(--color-tags);
+  white-space: nowrap;
 }

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -57,6 +57,7 @@
   margin: 0;
   color: inherit;
   border: 1px solid transparent;
+  background: transparent;
   border-top-left-radius: 2px;
   border-bottom-left-radius: 2px;
   padding: 2px 7px;
@@ -88,6 +89,7 @@
 .invisibleWrapperDirty .invisibleInput,
 .invisibleWrapper .invisibleInput:focus {
   border-color: var(--color-border);
+  background: var(--color-white);
 
   & + .invisibleSubmit {
     opacity: 1;

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -61,7 +61,7 @@
   border-top-left-radius: 2px;
   border-bottom-left-radius: 2px;
   padding: 2px 7px;
-  transition: border-color .2s;
+  transition: border-color .2s, background-color .2s;
   outline: 0;
 
   &::placeholder {

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -60,7 +60,7 @@
   background: transparent;
   border-top-left-radius: 2px;
   border-bottom-left-radius: 2px;
-  padding: 2px 7px;
+  padding: 0 7px;
   transition: border-color .2s, background-color .2s;
   outline: 0;
 
@@ -111,6 +111,6 @@
 }
 
 .invisiblePencil {
-  height: 16px;
-  width: 16px;
+  height: 1em;
+  width: 1em;
 }

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -63,6 +63,15 @@
   padding: 2px 7px;
   transition: border-color .2s;
   outline: 0;
+
+  &::placeholder {
+    color: inherit;
+    opacity: 1;
+  }
+}
+
+.invisibleInputEmpty {
+  font-style: italic;
 }
 
 .invisibleSubmit {

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -68,6 +68,10 @@
     color: inherit;
     opacity: 1;
   }
+
+  &:focus::placeholder {
+    color: var(--color-border);
+  }
 }
 
 .invisibleInputEmpty {

--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -110,7 +110,7 @@
   background-color: var(--color-palegrey);
 }
 
-.invisiblePencil {
+.invisibleWrapper .invisiblePencil {
   height: 1em;
   width: 1em;
 }

--- a/packages/fyndiq-component-input/src/__snapshots__/invisible.test.js.snap
+++ b/packages/fyndiq-component-input/src/__snapshots__/invisible.test.js.snap
@@ -10,7 +10,10 @@ exports[`fyndiq-component-input Invisible should have the proper structure 1`] =
   onSubmit={[Function]}
 >
   <input
-    className="invisibleInput"
+    className="
+            invisibleInput
+            invisibleInputEmpty
+          "
     onChange={[Function]}
     onKeyDown={[Function]}
   />

--- a/packages/fyndiq-component-input/src/invisible.js
+++ b/packages/fyndiq-component-input/src/invisible.js
@@ -53,7 +53,7 @@ class InvisibleInput extends React.Component {
   }
 
   render() {
-    const { className } = this.props
+    const { className, onChange, value, ...props } = this.props
 
     return (
       <form
@@ -69,10 +69,14 @@ class InvisibleInput extends React.Component {
           value={this.state.value}
           onChange={this.onChange}
           onKeyDown={this.onInputKeydown}
-          className={styles.invisibleInput}
+          className={`
+            ${styles.invisibleInput}
+            ${!this.state.value && styles.invisibleInputEmpty}
+          `}
           ref={element => {
             this.inputElement = element
           }}
+          {...props}
         />
         <button type="submit" className={styles.invisibleSubmit}>
           <Pencil className={styles.invisiblePencil} />

--- a/packages/fyndiq-component-input/src/invisible.test.js
+++ b/packages/fyndiq-component-input/src/invisible.test.js
@@ -37,6 +37,12 @@ describe('fyndiq-component-input Invisible', () => {
     expect(component.find('input').prop('value')).toBe('newValue')
   })
 
+  it('should not have a empty class when not empty', () => {
+    const component = shallow(<Invisible value="test" />)
+
+    expect(component.find('.invisibleInputEmpty').exists()).toBe(false)
+  })
+
   it('should call onChange', () => {
     const spy = jest.fn()
     const component = mount(<Invisible value="test" onChange={spy} />)

--- a/packages/fyndiq-component-layout/README.md
+++ b/packages/fyndiq-component-layout/README.md
@@ -1,0 +1,58 @@
+# fyndiq-component-layout [![npm](https://img.shields.io/npm/v/fyndiq-component-layout.svg?maxAge=3600)](https://www.npmjs.com/package/fyndiq-component-layout)
+
+A set of Layout components for Fyndiq
+
+# Installation
+
+The component can be installed through NPM:
+
+``` bash
+npm i -S fyndiq-component-layout
+```
+
+# `<Sidebar />`
+
+[Demo](http://developers.fyndiq.com/fyndiq-ui/?selectedKind=Layout%2FSidebar&selectedStory=default)
+
+This component helps to create a nice Sidebar. **It has a peerDependency on react-router-dom** since it
+uses React Router's [NavLink](https://reacttraining.com/react-router/web/api/NavLink) component.
+
+## Usage
+
+``` js
+import React from 'react'
+import { Sidebar } from 'fyndiq-component-layout'
+import { Bag, Shop } from 'fyndiq-icons'
+
+// Normal usage
+<Sidebar items={[
+  {
+    name: 'Orders',
+    icon: <Bag />,
+    to: '/orders',
+  }, {
+    name: 'Articles',
+    icon: <Shop />,
+    to: '/articles',
+  }
+]} />
+```
+
+## API
+
+The component `Input` has the following customizable props:
+
+| Name | Type | Description | Default value |
+|---|---|---|---|
+| **items** | Array | Items describing the content of the sidebar | `[]` |
+
+**NOTE ON BEST PRACTICES:** Because of the way NavLink handles active links, it's always good to
+have children routes under the parent routes.
+
+#### Example:
+
+- `/orders/`: root route
+- `/orders/create`: create route
+- `/orders/:id`: view order route
+
+(Note the `/orders/` which is always the same)

--- a/packages/fyndiq-component-layout/layout.css
+++ b/packages/fyndiq-component-layout/layout.css
@@ -1,0 +1,9 @@
+.layoutWrapper {
+  display: flex;
+  min-height: calc(100vh - 56px); /* Remove header height */
+}
+
+.layoutPageWrapper {
+  flex: 1;
+  background: #E9EAF0;
+}

--- a/packages/fyndiq-component-layout/package.json
+++ b/packages/fyndiq-component-layout/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fyndiq-component-layout",
+  "version": "2.0.0",
+  "author": "Thibaut Remy <thibaut.remy@fyndiq.com>",
+  "main": "lib/index.js",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/fyndiq/fyndiq-ui.git"
+  },
+  "homepage": "http://developers.fyndiq.com/fyndiq-ui/?selectedKind=Layout&selectedStory=default",
+  "dependencies": {
+    "fyndiq-styles-colors": "*"
+  },
+  "peerDependencies": {
+    "css-loader": "^0.28.7",
+    "postcss-cssnext": "^3.0.2",
+    "postcss-import": "^11.0.0",
+    "postcss-loader": "^2.0.6",
+    "prop-types": "^15.0.0",
+    "react": "^15.0.0 || ^16.0.0",
+    "react-router-dom": "^4.2.2"
+  }
+}

--- a/packages/fyndiq-component-layout/sidebar.css
+++ b/packages/fyndiq-component-layout/sidebar.css
@@ -1,0 +1,45 @@
+@import "fyndiq-styles-colors/colors.css";
+
+.wrapper {
+  min-width: 210px;
+  padding-top: 50px;
+}
+
+.list {
+  padding: 0;
+  margin: 0;
+
+  & li {
+    list-style-type: none;
+  }
+}
+
+.link {
+  display: flex;
+  align-items: center;
+  margin-bottom: 10px;
+  padding: 6px 36px;
+  text-decoration: none;
+  color: var(--color-black);
+  font-weight: 300;
+
+  &:hover {
+    background-color: var(--color-palegrey);
+  }
+
+  & .icon {
+    margin-right: 20px;
+    width: 18px;
+    stroke: var(--color-black);
+  }
+}
+
+.activeLink {
+  color: var(--color-red);
+  font-weight: 900;
+  box-shadow: inset 4px 0 0 0 var(--color-red);
+
+  & .icon {
+    stroke: var(--color-red);
+  }
+}

--- a/packages/fyndiq-component-layout/src/index.js
+++ b/packages/fyndiq-component-layout/src/index.js
@@ -1,0 +1,3 @@
+import Sidebar from './sidebar'
+
+export { Sidebar }

--- a/packages/fyndiq-component-layout/src/index.js
+++ b/packages/fyndiq-component-layout/src/index.js
@@ -1,3 +1,5 @@
 import Sidebar from './sidebar'
+import Layout from './layout'
 
-export { Sidebar }
+export { Sidebar, Layout }
+export default Layout

--- a/packages/fyndiq-component-layout/src/layout.js
+++ b/packages/fyndiq-component-layout/src/layout.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import styles from '../layout.css'
+
+const Layout = ({ sidebar, children }) => (
+  <div className={styles.layoutWrapper}>
+    {sidebar}
+    <div className={styles.layoutPageWrapper}>{children}</div>
+  </div>
+)
+
+Layout.propTypes = {
+  sidebar: PropTypes.element,
+  children: PropTypes.node,
+}
+
+Layout.defaultProps = {
+  sidebar: null,
+  children: null,
+}
+
+export default Layout

--- a/packages/fyndiq-component-layout/src/sidebar.js
+++ b/packages/fyndiq-component-layout/src/sidebar.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { NavLink } from 'react-router-dom'
+
+import styles from '../sidebar.css'
+
+const Sidebar = ({ items }) => (
+  <div className={styles.wrapper}>
+    <ul className={styles.list}>
+      {items.map(item => (
+        <li key={item.to}>
+          <NavLink
+            to={item.to}
+            activeClassName={styles.activeLink}
+            className={styles.link}
+          >
+            {React.cloneElement(item.icon, {
+              className: styles.icon,
+            })}
+            {item.name}
+          </NavLink>
+        </li>
+      ))}
+    </ul>
+  </div>
+)
+
+Sidebar.propTypes = {
+  items: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.node,
+      to: PropTypes.string,
+      icon: PropTypes.element,
+    }),
+  ),
+}
+
+Sidebar.defaultProps = {
+  items: [],
+}
+
+export default Sidebar

--- a/packages/fyndiq-component-table/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-table/src/__snapshots__/index.test.js.snap
@@ -13,19 +13,31 @@ exports[`fyndiq-component-table Cell component should have the right structure 1
 `;
 
 exports[`fyndiq-component-table Row component should have the right structure 1`] = `
-<tr
-  className="
-      row
-      false
-      false
-      false
-      rowVerticalCenter
-      rowSize-m
-      className
-    "
->
-  Content
-</tr>
+<React.Fragment>
+  <tr
+    className="
+        row
+        false
+        false
+        false
+        rowSize-m
+        false
+        false
+        className
+      "
+  >
+    <td
+      className="cellSpacer cell"
+    />
+    Content
+    <td
+      className="cellSpacer cell"
+    />
+  </tr>
+  <tr
+    className="rowSpacer"
+  />
+</React.Fragment>
 `;
 
 exports[`fyndiq-component-table Table component should have the right structure 1`] = `

--- a/packages/fyndiq-component-table/src/index.test.js
+++ b/packages/fyndiq-component-table/src/index.test.js
@@ -20,25 +20,66 @@ describe('fyndiq-component-table', () => {
     })
 
     it('should have a interactive prop', () => {
-      expect(shallow(<Row interactive />).hasClass('rowInteractive')).toBe(true)
+      expect(
+        shallow(<Row interactive />)
+          .find('.row')
+          .hasClass('rowInteractive'),
+      ).toBe(true)
     })
 
     it('should have a head prop', () => {
-      expect(shallow(<Row head />).hasClass('rowHead')).toBe(true)
-    })
-
-    it('should have a noBorder prop', () => {
-      expect(shallow(<Row noBorder />).hasClass('rowNoBorder')).toBe(true)
+      expect(
+        shallow(<Row head />)
+          .find('.row')
+          .hasClass('rowHead'),
+      ).toBe(true)
     })
 
     it('should have a verticalCenter prop', () => {
       expect(
-        shallow(<Row verticalCenter />).hasClass('rowVerticalCenter'),
+        shallow(<Row verticalCenter />)
+          .find('.row')
+          .hasClass('rowVerticalCenter'),
       ).toBe(true)
     })
 
     it('should have a size prop', () => {
-      expect(shallow(<Row size="l" />).hasClass('rowSize-l')).toBe(true)
+      expect(
+        shallow(<Row size="l" />)
+          .find('.row')
+          .hasClass('rowSize-l'),
+      ).toBe(true)
+    })
+
+    describe('Linked Rows', () => {
+      const row1 = shallow(<Row id={0} length={3} />)
+      const row2 = shallow(<Row id={1} length={3} />)
+      const row3 = shallow(<Row id={2} length={3} />)
+
+      it('should not be a linked row if `id` and `length` are not specified', () => {
+        const row = shallow(<Row />)
+        expect(row.find('.row').hasClass('rowStart')).toBe(false)
+        expect(row.find('.row').hasClass('rowEnd')).toBe(false)
+        expect(row.find('.rowSpacer').exists()).toBe(true)
+      })
+
+      it('should have a class rowStart except the last one', () => {
+        expect(row1.find('.row').hasClass('rowStart')).toBe(true)
+        expect(row2.find('.row').hasClass('rowStart')).toBe(true)
+        expect(row3.find('.row').hasClass('rowStart')).toBe(false)
+      })
+
+      it('should have a class rowEnd expect the first one', () => {
+        expect(row1.find('.row').hasClass('rowEnd')).toBe(false)
+        expect(row2.find('.row').hasClass('rowEnd')).toBe(true)
+        expect(row3.find('.row').hasClass('rowEnd')).toBe(true)
+      })
+
+      it('should have a rowSpacer only at the end', () => {
+        expect(row1.find('.rowSpacer').exists()).toBe(false)
+        expect(row2.find('.rowSpacer').exists()).toBe(false)
+        expect(row3.find('.rowSpacer').exists()).toBe(true)
+      })
     })
   })
 

--- a/packages/fyndiq-component-table/src/row.js
+++ b/packages/fyndiq-component-table/src/row.js
@@ -32,7 +32,7 @@ const Row = ({
       {children}
       <td className={`${styles.cellSpacer} ${styles.cell}`} />
     </tr>
-    <tr className={styles.rowSpacer} />
+    {id === length && <tr className={styles.rowSpacer} />}
   </React.Fragment>
 )
 
@@ -43,6 +43,8 @@ Row.propTypes = {
   size: PropTypes.oneOf(['s', 'm', 'l']),
   children: PropTypes.node,
   verticalCenter: PropTypes.bool,
+  id: PropTypes.number,
+  length: PropTypes.number,
 }
 
 Row.defaultProps = {
@@ -52,6 +54,8 @@ Row.defaultProps = {
   interactive: false,
   size: 'm',
   verticalCenter: false,
+  id: 1,
+  length: 1,
 }
 
 export default Row

--- a/packages/fyndiq-component-table/src/row.js
+++ b/packages/fyndiq-component-table/src/row.js
@@ -23,7 +23,7 @@ const Row = ({
         ${verticalCenter && styles.rowVerticalCenter}
         ${styles[`rowSize-${size}`]}
         ${id < length - 1 && length !== 1 && styles.rowStart}
-        ${id !== 0 && id <= length && styles.rowEnd}
+        ${id !== 0 && styles.rowEnd}
         ${className}
       `}
       {...props}
@@ -32,7 +32,7 @@ const Row = ({
       {children}
       <td className={`${styles.cellSpacer} ${styles.cell}`} />
     </tr>
-    {id === length && <tr className={styles.rowSpacer} />}
+    {id === length - 1 && <tr className={styles.rowSpacer} />}
   </React.Fragment>
 )
 
@@ -54,7 +54,7 @@ Row.defaultProps = {
   interactive: false,
   size: 'm',
   verticalCenter: false,
-  id: 1,
+  id: 0,
   length: 1,
 }
 

--- a/packages/fyndiq-component-table/src/row.js
+++ b/packages/fyndiq-component-table/src/row.js
@@ -8,32 +8,38 @@ const Row = ({
   head,
   interactive,
   className,
-  noBorder,
   size,
   verticalCenter,
+  id,
+  length,
   ...props
 }) => (
-  <tr
-    className={`
-      ${styles.row}
-      ${head && styles.rowHead}
-      ${interactive && styles.rowInteractive}
-      ${noBorder && styles.rowNoBorder}
-      ${verticalCenter && styles.rowVerticalCenter}
-      ${styles[`rowSize-${size}`]}
-      ${className}
-    `}
-    {...props}
-  >
-    {children}
-  </tr>
+  <React.Fragment>
+    <tr
+      className={`
+        ${styles.row}
+        ${head && styles.rowHead}
+        ${interactive && styles.rowInteractive}
+        ${verticalCenter && styles.rowVerticalCenter}
+        ${styles[`rowSize-${size}`]}
+        ${id < length - 1 && length !== 1 && styles.rowStart}
+        ${id !== 0 && id <= length && styles.rowEnd}
+        ${className}
+      `}
+      {...props}
+    >
+      <td className={`${styles.cellSpacer} ${styles.cell}`} />
+      {children}
+      <td className={`${styles.cellSpacer} ${styles.cell}`} />
+    </tr>
+    <tr className={styles.rowSpacer} />
+  </React.Fragment>
 )
 
 Row.propTypes = {
   head: PropTypes.bool,
   interactive: PropTypes.bool,
   className: PropTypes.string,
-  noBorder: PropTypes.bool,
   size: PropTypes.oneOf(['s', 'm', 'l']),
   children: PropTypes.node,
   verticalCenter: PropTypes.bool,
@@ -41,12 +47,11 @@ Row.propTypes = {
 
 Row.defaultProps = {
   className: '',
-  noBorder: false,
   children: null,
   head: false,
   interactive: false,
   size: 'm',
-  verticalCenter: true,
+  verticalCenter: false,
 }
 
 export default Row

--- a/packages/fyndiq-component-table/table.css
+++ b/packages/fyndiq-component-table/table.css
@@ -5,15 +5,53 @@
   width: 100%;
 }
 
-.row {
-  &:not(.rowNoBorder) {
-    border-bottom: 1px solid var(--color-border);
-  }
-}
-
 .cell {
   vertical-align: top;
   padding: 0 8px;
+}
+
+.row {
+  box-shadow: 0 0 5px 0 color(var(--color-black) a(10%));
+
+  & > .cell {
+    background: var(--color-white);
+  }
+
+  & > :first-child {
+    border-top-left-radius: 2px;
+    border-bottom-left-radius: 2px;
+  }
+
+  & > :last-child {
+    border-top-right-radius: 2px;
+    border-bottom-right-radius: 2px;
+  }
+}
+
+.rowStart {
+  & > :first-child {
+    border-bottom-left-radius: 0;
+  }
+
+  & > :last-child {
+    border-bottom-right-radius: 0;
+  }
+}
+
+.rowEnd {
+  box-shadow: 5px 5px 5px -5px color(var(--color-black) a(10%)), -5px 5px 5px -5px color(var(--color-black) a(10%));
+
+  & > :first-child {
+    border-top-left-radius: 0;
+  }
+
+  & > :last-child {
+    border-top-right-radius: 0;
+  }
+}
+
+.rowStart.rowEnd {
+  box-shadow: 5px 0 5px -5px color(var(--color-black) a(10%)), -5px 0 5px -5px color(var(--color-black) a(10%));
 }
 
 .rowSize-l .cell {
@@ -32,26 +70,37 @@
 }
 
 .rowHead {
-  font-weight: 900;
+  white-space: nowrap;
   font-size: 13px;
-  color: var(--color-border);
+  color: var(--color-lightgrey);
+  font-weight: 300;
+  box-shadow: none;
 
   & .cell {
     padding-top: 18px;
     padding-bottom: 18px;
-  }
-}
-
-.rowInteractive {
-  cursor: pointer;
-
-  &:hover {
-    background: var(--color-palegrey);
+    background-color: transparent;
   }
 }
 
 .rowVerticalCenter .cell {
   vertical-align: middle;
+}
+
+.rowInteractive {
+  cursor: pointer;
+
+  &:hover .cell {
+    background: var(--color-palegrey);
+  }
+}
+
+.rowSpacer {
+  height: 2px;
+}
+
+.cellSpacer {
+  width: 20px;
 }
 
 .cellCenter {

--- a/packages/fyndiq-component-tooltip/README.md
+++ b/packages/fyndiq-component-tooltip/README.md
@@ -36,6 +36,7 @@ The component `Stars` has the following customizable props:
 | **text** | Node | The tooltip text | `null` |
 | **children** | Node | Content over which the tooltip should show up | `null` |
 | **className** | String | Classname of the tooltip wrapper | `''` |
+| **wrapperClassName** | String | Classname of the dropdown wrapper (parent of className) | `''` |
 | **position** | String | The position of the tooltip (see [Dropdown's API](../fyndiq-component-dropdown#api) for possible values) | `bc` |
 | **maxWidth** | Number | Max width of the tooltip | `190` | 
 

--- a/packages/fyndiq-component-tooltip/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-tooltip/src/__snapshots__/index.test.js.snap
@@ -73,6 +73,7 @@ exports[`fyndiq-component-tooltip should not have a tooltip if the text is null 
   position="bc"
   text={null}
   type="black"
+  wrapperClassName=""
 >
   tooltip
 </Tooltip>

--- a/packages/fyndiq-component-tooltip/src/index.js
+++ b/packages/fyndiq-component-tooltip/src/index.js
@@ -28,10 +28,16 @@ class Tooltip extends React.Component {
 
     this.state = { width: this.props.maxWidth }
 
-    this.onDropdownOpen = this.onDropdownOpen.bind(this)
+    this.recalculateWidth = this.recalculateWidth.bind(this)
   }
 
-  onDropdownOpen() {
+  componentDidUpdate(prevProps) {
+    if (prevProps.text !== this.props.text) {
+      this.recalculateWidth()
+    }
+  }
+
+  recalculateWidth() {
     // Clone the wrapper node and hide it
     // The reason we're doing that is because of the animation
     // on the underlying Dropdown wrapper : calculating the width
@@ -39,6 +45,7 @@ class Tooltip extends React.Component {
     // in a wrong width
     const cloneNode = this.wrapperElement.cloneNode(true)
     cloneNode.style.opacity = '0'
+    cloneNode.style.width = 'initial'
 
     document.body.appendChild(cloneNode)
 
@@ -62,7 +69,7 @@ class Tooltip extends React.Component {
         hoverMode
         noWrapperStyle
         position={position}
-        onOpen={this.onDropdownOpen}
+        onOpen={this.recalculateWidth}
       >
         <div
           className={`

--- a/packages/fyndiq-component-tooltip/src/index.js
+++ b/packages/fyndiq-component-tooltip/src/index.js
@@ -9,6 +9,7 @@ class Tooltip extends React.Component {
     type: PropTypes.oneOf(['black', 'white']),
     text: PropTypes.node,
     className: PropTypes.string,
+    wrapperClassName: PropTypes.string,
     children: PropTypes.node,
     maxWidth: PropTypes.number,
     position: Dropdown.propTypes.position, // eslint-disable-line react/no-typos
@@ -19,6 +20,7 @@ class Tooltip extends React.Component {
     text: null,
     children: null,
     className: '',
+    wrapperClassName: '',
     position: 'bc',
     maxWidth: 190,
   }
@@ -59,7 +61,14 @@ class Tooltip extends React.Component {
   }
 
   render() {
-    const { type, text, children, position, className } = this.props
+    const {
+      type,
+      text,
+      children,
+      position,
+      className,
+      wrapperClassName,
+    } = this.props
 
     if (!text) return children
 
@@ -70,6 +79,7 @@ class Tooltip extends React.Component {
         noWrapperStyle
         position={position}
         onOpen={this.recalculateWidth}
+        wrapperClassName={wrapperClassName}
       >
         <div
           className={`

--- a/packages/fyndiq-component-tooltip/src/index.test.js
+++ b/packages/fyndiq-component-tooltip/src/index.test.js
@@ -36,6 +36,14 @@ describe('fyndiq-component-tooltip', () => {
     ).toBe(true)
   })
 
+  test('should have a wrapperClassName prop', () => {
+    expect(
+      shallow(<Tooltip text="text" wrapperClassName="test-classname" />)
+        .find('Dropdown')
+        .prop('wrapperClassName'),
+    ).toBe('test-classname')
+  })
+
   test('should have a type prop', () => {
     expect(
       shallow(<Tooltip text="text" type="white" />)

--- a/packages/fyndiq-icons/README.md
+++ b/packages/fyndiq-icons/README.md
@@ -12,7 +12,7 @@ npm i -S fyndiq-icons
 
 # Usage
 
-To see the name of the icons in the set, please visit the [demo](//http://developers.fyndiq.com/fyndiq-ui/?selectedKind=Icons&selectedStory=default)
+To see the name of the icons in the set, please visit the [demo](http://developers.fyndiq.com/fyndiq-ui/?selectedKind=Icons&selectedStory=default)
 
 ``` js
 import React from 'react'

--- a/packages/fyndiq-icons/src/attributes.js
+++ b/packages/fyndiq-icons/src/attributes.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import SvgWrapper from './svg-wrapper'
+
+const Attributes = ({ className, color }) => (
+  <SvgWrapper className={className} viewBox="0 0 12 16">
+    <rect
+      x=".5"
+      y="4.5"
+      width="11"
+      height="11"
+      rx="1"
+      fill="none"
+      stroke={color}
+    />
+    <path
+      d="M1.5 2.5h9m-8-2h7"
+      fill="none"
+      stroke={color}
+      strokeLinecap="round"
+    />
+  </SvgWrapper>
+)
+
+Attributes.propTypes = SvgWrapper.propTypes
+Attributes.defaultProps = SvgWrapper.defaultProps
+
+export default Attributes

--- a/packages/fyndiq-icons/src/index.js
+++ b/packages/fyndiq-icons/src/index.js
@@ -1,5 +1,6 @@
 import Arrow from './arrow'
 import Atm from './atm'
+import Attributes from './attributes'
 import Bag from './bag'
 import Checkmark from './checkmark'
 import Error from './error'
@@ -10,12 +11,15 @@ import Pencil from './pencil'
 import Regret from './regret'
 import Shop from './shop'
 import Star from './star'
+import Tags from './tags'
 import Truck from './truck'
 import Warning from './warning'
+import X from './x'
 
 export {
   Arrow,
   Atm,
+  Attributes,
   Bag,
   Checkmark,
   Error,
@@ -26,6 +30,8 @@ export {
   Regret,
   Shop,
   Star,
+  Tags,
   Truck,
   Warning,
+  X,
 }

--- a/packages/fyndiq-icons/src/tags.js
+++ b/packages/fyndiq-icons/src/tags.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import SvgWrapper from './svg-wrapper'
+
+const Tags = ({ className, color }) => (
+  <SvgWrapper className={className} viewBox="0 0 20 20">
+    <path
+      d="M18.14 1.23l-6.22.06a.67.67 0 0 0-.47.2L1.38 11.54a.71.71 0 0 0 .03 1l6.04 6.04c.28.29.73.3 1 .03L18.52 8.55a.68.68 0 0 0 .2-.47l.08-6.18a.75.75 0 0 0-.66-.67z"
+      fill="none"
+      stroke={color}
+      strokeLinejoin="round"
+    />
+    <path
+      d="M15.68 6.44a1.5 1.5 0 1 1-2.12-2.12 1.5 1.5 0 0 1 2.12 2.12z"
+      fill="none"
+      stroke={color}
+      strokeLinejoin="round"
+    />
+  </SvgWrapper>
+)
+
+Tags.propTypes = SvgWrapper.propTypes
+Tags.defaultProps = SvgWrapper.defaultProps
+
+export default Tags

--- a/packages/fyndiq-icons/src/x.js
+++ b/packages/fyndiq-icons/src/x.js
@@ -1,0 +1,18 @@
+import React from 'react'
+import SvgWrapper from './svg-wrapper'
+
+const X = ({ className, color }) => (
+  <SvgWrapper className={className} viewBox="0 0 23 23">
+    <path
+      d="M.8.8l21.4 21.4m-21.4 0L22.2.8"
+      fill="none"
+      stroke={color}
+      strokeLinecap="round"
+    />
+  </SvgWrapper>
+)
+
+X.propTypes = SvgWrapper.propTypes
+X.defaultProps = SvgWrapper.defaultProps
+
+export default X

--- a/packages/fyndiq-styles-colors/colors.css
+++ b/packages/fyndiq-styles-colors/colors.css
@@ -19,8 +19,9 @@
   /* Contextual colors */
   --color-return: #2699F7;
   --color-reclamation: #BC26F7;
-  --color-missing: #F7A626;
+  --color-missing: var(--color-orange);
   --color-yellow-deal: #FE0;
+  --color-tags: var(--color-orange);
 
   /* Component colors */
   --color-border: #CCD1DD;

--- a/packages/fyndiq-ui-test/.storybook/config.js
+++ b/packages/fyndiq-ui-test/.storybook/config.js
@@ -15,6 +15,7 @@ function loadStories() {
   require('../stories/component-checkbox')
   require('../stories/component-dropdown')
   require('../stories/component-input')
+  require('../stories/component-layout')
   require('../stories/component-loader')
   require('../stories/component-message')
   require('../stories/component-modal')

--- a/packages/fyndiq-ui-test/package.json
+++ b/packages/fyndiq-ui-test/package.json
@@ -12,6 +12,7 @@
     "fyndiq-component-checkbox": "^2.3.3",
     "fyndiq-component-dropdown": "^2.8.1",
     "fyndiq-component-input": "^2.2.3",
+    "fyndiq-component-layout": "^2.0.0",
     "fyndiq-component-loader": "^2.2.0",
     "fyndiq-component-message": "^2.2.2",
     "fyndiq-component-modal": "^2.4.0",

--- a/packages/fyndiq-ui-test/stories/component-layout.js
+++ b/packages/fyndiq-ui-test/stories/component-layout.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { BrowserRouter } from 'react-router-dom'
+import { Sidebar } from 'fyndiq-component-layout'
+import { Bag, Shop } from 'fyndiq-icons'
+
+storiesOf('Layout/Sidebar', module)
+  .addDecorator(story => <BrowserRouter>{story()}</BrowserRouter>)
+  .addWithInfo('default', () => (
+    <Sidebar
+      items={[
+        {
+          name: 'Bag',
+          icon: <Bag />,
+          to: '#bag',
+        },
+        {
+          name: 'Shop',
+          icon: <Shop />,
+          to: '#shop',
+        },
+      ]}
+    />
+  ))

--- a/packages/fyndiq-ui-test/stories/component-table.js
+++ b/packages/fyndiq-ui-test/stories/component-table.js
@@ -3,6 +3,18 @@ import { storiesOf } from '@storybook/react'
 import { Table, Row, Cell } from 'fyndiq-component-table'
 
 storiesOf('Table', module)
+  .addDecorator(story => (
+    <div
+      style={{
+        margin: -8,
+        backgroundColor: '#E9EAF0',
+        minHeight: '100vh',
+        padding: 20,
+      }}
+    >
+      {story()}
+    </div>
+  ))
   .addWithInfo('default', () => (
     <Table>
       <Row head>
@@ -41,8 +53,29 @@ storiesOf('Table', module)
       <Row interactive>
         <Cell>I&apos;m a row that reacts on mouse hover</Cell>
       </Row>
-      <Row noBorder>
-        <Cell>I&apos;m a row that doesn&apos;t have a bottom border</Cell>
+    </Table>
+  ))
+  .addWithInfo('linked rows', () => (
+    <Table>
+      <Row id={0} length={3}>
+        <Cell>I'm a row that has some linked rows below</Cell>
+      </Row>
+      <Row id={1} length={3}>
+        <Cell>
+          The <code>id</code> prop specifies where in the list I am. Note that
+          it is 0-based.
+        </Cell>
+      </Row>
+      <Row id={2} length={3}>
+        <Cell>
+          And the <code>length</code> prop specifies how long the linked rows is
+        </Cell>
+      </Row>
+      <Row>
+        <Cell>
+          After that you can either reset the <code>id</code> or{' '}
+          <code>length</code> props to add normal rows or other linked rows
+        </Cell>
       </Row>
     </Table>
   ))

--- a/packages/fyndiq-ui-test/stories/component-table.js
+++ b/packages/fyndiq-ui-test/stories/component-table.js
@@ -2,6 +2,8 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Table, Row, Cell } from 'fyndiq-component-table'
 
+/* eslint-disable react/no-unescaped-entities */
+
 storiesOf('Table', module)
   .addDecorator(story => (
     <div
@@ -42,16 +44,16 @@ storiesOf('Table', module)
   .addWithInfo('row customization', () => (
     <Table>
       <Row size="l">
-        <Cell>I&apos;m a large row</Cell>
+        <Cell>I'm a large row</Cell>
       </Row>
       <Row size="m">
-        <Cell>I&apos;m a default size row</Cell>
+        <Cell>I'm a default size row</Cell>
       </Row>
       <Row size="s">
-        <Cell>I&apos;m a small row</Cell>
+        <Cell>I'm a small row</Cell>
       </Row>
       <Row interactive>
-        <Cell>I&apos;m a row that reacts on mouse hover</Cell>
+        <Cell>I'm a row that reacts on mouse hover</Cell>
       </Row>
     </Table>
   ))


### PR DESCRIPTION
## Overview

This PR updates several components:

🆕  Add `fyndiq-component-layout`, which exposes a `<Sidebar />` and a `<Layout />` component.
💥  Use the "pill table" as the regular table for `fyndiq-component-table`
🔧  `<InvisibleInput />` now passes rest props to the input element.
👀  `<InvisibleInput />` has italic style when the input is empty
🔧 `<Tooltip />` has a new prop: `wrapperClassName`
🆕 3 New Icons for fyndiq-icons
🆕 New color for tags
👁 Change `<Tags />` layout