### PR TITLE
Confirm component and utility

### DIFF
--- a/packages/fyndiq-component-modal/README.md
+++ b/packages/fyndiq-component-modal/README.md
@@ -91,17 +91,27 @@ The easiest way to create a confirm flow is to use the `confirm` creation utilit
 
 ``` js
 import React from 'react'
-import { Confirm, confirm } from 'fyndiq-component-modal'
+import { Confirm, ConfirmWrapper, confirm } from 'fyndiq-component-modal'
 
- // Here just for the demo
+// First you need to render the <ConfirmWrapper /> somewhere on your app.
+// It is recommended that you put it somewhere in the root of your app:
+const MyApp = () => (
+  <React.Fragment>
+    <ConfirmWrapper />
+    <Layout /> {/* Rest of your app*/}
+  </React.Fragment>
+)
+
+// This example shows how to display a warning confirm dialog,
+// that pops up when the user clicks on a Delete button.
 import { Warning } from 'fyndiq-icons'
 import Button from 'fyndiq-component-button'
 
 <Button onClick={confirmDelete}>
-  Delete something
+  ⚠️ Delete something
 </Button>
 
-// This example uses async/await
+// Here is where the magic happens ✨
 async confirmDelete() => {
   const isValidated = await confirm(
     <Confirm

--- a/packages/fyndiq-component-modal/README.md
+++ b/packages/fyndiq-component-modal/README.md
@@ -6,19 +6,24 @@ A Modal component for Fyndiq
 
 # Installation
 
-The component can be installed through NPM:
+The package can be installed through NPM:
 
 ``` bash
 npm i -S fyndiq-component-modal
 ```
 
-# Usage
+It exports two main components: a `Modal` component which is fully customizable, as well as a `confirm` utility
+to quickly create beautiful confirm dialogs.
+
+# Modal
+
+##  Usage
 
 The easiest way to use the `Modal` component is to open it using `ModalButton` component:
 
 ``` js
 import React from 'react'
-import { ModalButton } from 'fyndiq-component-mycomponent'
+import { ModalButton } from 'fyndiq-component-modal'
 
 // Normal usage
 <ModalButton button="Open Modal">
@@ -32,7 +37,7 @@ To customize the modal itself, you can pass it as a children:
 
 ``` js
 import React from 'react'
-import Modal, { ModalButton } from 'fyndiq-component-mycomponent'
+import Modal, { ModalButton } from 'fyndiq-component-modal'
 
 // Advanced styling
 <ModalButton>
@@ -56,7 +61,7 @@ import Modal, { ModalButton } from 'fyndiq-component-mycomponent'
 
 For advanced use, you can use directly the `Modal` component and control its `open` prop, as well as binding the `onClose` callback prop.
 
-# API
+## API
 
 The component `Modal` has the following customizable props:
 
@@ -76,3 +81,56 @@ The component `ModalButton` has the following customizable props
 |---|---|---|---|
 | **button** | [Button](../fyndiq-component-button/) or String | Content of the button that will open the modal. If a string is passed, it will be converted to a Button Component | `Open Modal` |
 | **children** | React Element | Content of the modal. If the element is not a `Modal` Component, it will be wrapped into one. Pass a `Modal` component as children to allow customisation of the Modal. | `null` |
+
+
+# Confirm
+
+## Usage
+
+The easiest way to create a confirm flow is to use the `confirm` creation utility, as well as the `Confirm` React Component to customize its appearance.
+
+``` js
+import React from 'react'
+import { Confirm, confirm } from 'fyndiq-component-modal'
+
+ // Here just for the demo
+import { Warning } from 'fyndiq-icons'
+import Button from 'fyndiq-component-button'
+
+<Button onClick={confirmDelete}>
+  Delete something
+</Button>
+
+// This example uses async/await
+async confirmDelete() => {
+  const isValidated = await confirm(
+    <Confirm
+      type="warning"
+      icon={<Warning />}
+      title="Do you really want to delete that thing?"
+      message="If you delete it, there is no way back"
+      validateButton="Delete"
+    />
+  )
+
+  if (isValidated) {
+    // do something
+  }
+}
+```
+
+## API
+
+The component `Confirm` has the following customizable props
+
+| Name | Type | Description | Default value |
+|---|---|---|---|
+| **type** | String | Color scheme of the dialog. One of `info`, `warning`, `success` | `info` |
+| **title** | Node | Title of the notification | `Are you sure?` |
+| **message** | Node | Additional message for the popup | `''` |
+| **icon** | Icon | Icon shown on top of the confirm dialog | `null` |
+| **validateButton** | String or Button | Validate button (or text) | `OK` |
+| **cancelButton** | String or Button | Cancel button (or text) | `Cancel` |
+| **open** | Boolean | Shows or hide the confirm dialog. Used internally by the `confirm` utility | `true` |
+| **onValidate** | Function | Handler called when the user clicked on validate. Used internally by the `confirm` utility function | `()  => {}` |
+| **onCancel** | Function | Handler called when the user clicked on cancel. Used internally by the `confirm` utility function | `() => {}` |

--- a/packages/fyndiq-component-modal/confirm.css
+++ b/packages/fyndiq-component-modal/confirm.css
@@ -8,7 +8,8 @@
 
 .icon {
   display: block;
-  width: 40px;
+  width: 38px;
+  height: 38px;
   margin: 0 auto 25px;
 }
 

--- a/packages/fyndiq-component-modal/confirm.css
+++ b/packages/fyndiq-component-modal/confirm.css
@@ -1,0 +1,46 @@
+@import "fyndiq-styles-colors/colors.css";
+
+.wrapper {
+  width: 475px;
+  margin-top: 20vh;
+  padding: 24px 35px;
+}
+
+.icon {
+  display: block;
+  width: 40px;
+  margin: 0 auto 25px;
+}
+
+.wrapper--info {
+  & .icon {
+    fill: var(--color-blue);
+    stroke: var(--color-blue);
+  }
+}
+
+.wrapper--success {
+  & .icon {
+    fill: var(--color-green);
+    stroke: var(--color-green);
+  }
+}
+
+.wrapper--warning {
+  & .icon {
+    fill: var(--color-orange);
+    stroke: var(--color-orange);
+  }
+}
+
+.title {
+  display: block;
+  font-size: 16px;
+  line-height: 2;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  padding: 25px 0 0;
+}

--- a/packages/fyndiq-component-modal/confirm.css
+++ b/packages/fyndiq-component-modal/confirm.css
@@ -4,13 +4,14 @@
   width: 475px;
   margin-top: 20vh;
   padding: 24px 35px;
-}
 
-.icon {
-  display: block;
-  width: 38px;
-  height: 38px;
-  margin: 0 auto 25px;
+  /* Specificity is increased artificially */
+  & .icon {
+    display: block;
+    width: 38px;
+    height: 38px;
+    margin: 0 auto 25px;
+  }
 }
 
 .wrapper--info {

--- a/packages/fyndiq-component-modal/src/confirm-promise.js
+++ b/packages/fyndiq-component-modal/src/confirm-promise.js
@@ -1,0 +1,12 @@
+import ConfirmWrapper from './confirm-wrapper'
+
+export default modal =>
+  new Promise(resolve => {
+    ConfirmWrapper.setConfirm(modal, validate => {
+      if (validate) {
+        resolve(true)
+      } else {
+        resolve(false)
+      }
+    })
+  })

--- a/packages/fyndiq-component-modal/src/confirm-wrapper.js
+++ b/packages/fyndiq-component-modal/src/confirm-wrapper.js
@@ -1,0 +1,77 @@
+import React from 'react'
+
+import ModalPortal from './modal-portal'
+
+class ConfirmWrapper extends React.Component {
+  // Keep in memory a running instance of the wrapper
+  static instance = null
+
+  static setConfirm(confirm, callback) {
+    if (ConfirmWrapper.instance === null) {
+      throw new Error('ConfirmWrapper has no instance running')
+    }
+
+    ConfirmWrapper.instance.setConfirm(confirm, callback)
+  }
+
+  constructor(props) {
+    super(props)
+    this.state = { confirm: null }
+    this.setConfirm = this.setConfirm.bind(this)
+    this.onCancel = this.onCancel.bind(this)
+    this.onValidate = this.onValidate.bind(this)
+  }
+
+  componentWillMount() {
+    if (ConfirmWrapper.instance != null) {
+      console.warn('ConfirmWrapper already had an instance running')
+    }
+
+    ConfirmWrapper.instance = this
+  }
+
+  componentWillUnmount() {
+    ConfirmWrapper.instance = null
+  }
+
+  onCancel() {
+    this.callback(false)
+    this.unsetConfirm()
+  }
+
+  onValidate() {
+    this.callback(true)
+    this.unsetConfirm()
+  }
+
+  setConfirm(confirm, callback) {
+    if (this.callback != null) {
+      console.warn(
+        'A confirm callback was previously registered, and will be overwritten.',
+      )
+    }
+    this.callback = callback
+
+    this.setState({ confirm })
+  }
+
+  unsetConfirm() {
+    this.setState({ confirm: null })
+    this.callback = null
+  }
+
+  render() {
+    if (this.state.confirm == null) return null
+
+    return (
+      <ModalPortal>
+        {React.cloneElement(this.state.confirm, {
+          onCancel: this.onCancel,
+          onValidate: this.onValidate,
+        })}
+      </ModalPortal>
+    )
+  }
+}
+
+export default ConfirmWrapper

--- a/packages/fyndiq-component-modal/src/confirm.js
+++ b/packages/fyndiq-component-modal/src/confirm.js
@@ -1,0 +1,76 @@
+import React from 'react'
+
+import Button from 'fyndiq-component-button'
+
+import Modal from './modal'
+import styles from '../confirm.css'
+
+const Confirm = ({
+  open,
+  type,
+  title,
+  message,
+  icon,
+  validateButton,
+  cancelButton,
+  onValidate,
+  onCancel,
+}) => (
+  <Modal
+    open={open}
+    wrapperClassName={`
+      ${styles.wrapper}
+      ${styles[`wrapper--${type}`]}
+    `}
+    onClose={onCancel}
+  >
+    {React.cloneElement(icon, {
+      className: styles.icon,
+    })}
+
+    <strong className={styles.title}>{title}</strong>
+
+    <div>{message}</div>
+
+    <div className={styles.footer}>
+      {React.isValidElement(cancelButton) ? (
+        React.cloneElement(cancelButton, {
+          onClick: onCancel,
+        })
+      ) : (
+        <Button type="ghost" size="m" onClick={onCancel}>
+          {cancelButton}
+        </Button>
+      )}
+      {React.isValidElement(validateButton) ? (
+        React.cloneElement(validateButton, {
+          onClick: onValidate,
+        })
+      ) : (
+        <Button type="secondary" size="m" pill onClick={onValidate}>
+          {validateButton}
+        </Button>
+      )}
+    </div>
+  </Modal>
+)
+
+Confirm.defaultProps = {
+  type: 'info',
+  title: 'Are you sure?',
+  validateButton: 'OK',
+  cancelButton: 'Cancel',
+  open: true,
+}
+
+export default Confirm
+
+// // Usage in API
+
+// import { confirm, Confirm } from 'fyndiq-component-modal'
+
+// const a = async confirmButton() {
+//   const validated = await confirm(
+//     <Confirm type="warning" icon={<Warning />} title="Are you sure?" />
+//   )
+// }

--- a/packages/fyndiq-component-modal/src/confirm.js
+++ b/packages/fyndiq-component-modal/src/confirm.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 import Button from 'fyndiq-component-button'
 
@@ -33,44 +34,52 @@ const Confirm = ({
     <div>{message}</div>
 
     <div className={styles.footer}>
-      {React.isValidElement(cancelButton) ? (
-        React.cloneElement(cancelButton, {
-          onClick: onCancel,
-        })
-      ) : (
-        <Button type="ghost" size="m" onClick={onCancel}>
-          {cancelButton}
-        </Button>
-      )}
-      {React.isValidElement(validateButton) ? (
-        React.cloneElement(validateButton, {
-          onClick: onValidate,
-        })
-      ) : (
-        <Button type="secondary" size="m" pill onClick={onValidate}>
-          {validateButton}
-        </Button>
-      )}
+      {cancelButton &&
+        (React.isValidElement(cancelButton) ? (
+          React.cloneElement(cancelButton, {
+            onClick: onCancel,
+          })
+        ) : (
+          <Button type="ghost" size="m" onClick={onCancel}>
+            {cancelButton}
+          </Button>
+        ))}
+      {validateButton &&
+        (React.isValidElement(validateButton) ? (
+          React.cloneElement(validateButton, {
+            onClick: onValidate,
+          })
+        ) : (
+          <Button type="secondary" size="m" pill onClick={onValidate}>
+            {validateButton}
+          </Button>
+        ))}
     </div>
   </Modal>
 )
 
+Confirm.propTypes = {
+  open: PropTypes.bool,
+  type: PropTypes.oneOf(['warning', 'info', 'success']),
+  title: PropTypes.node,
+  message: PropTypes.node,
+  icon: PropTypes.element,
+  validateButton: PropTypes.node,
+  cancelButton: PropTypes.node,
+  onValidate: PropTypes.func,
+  onCancel: PropTypes.func,
+}
+
 Confirm.defaultProps = {
+  open: true,
   type: 'info',
   title: 'Are you sure?',
+  message: '',
+  icon: null,
   validateButton: 'OK',
   cancelButton: 'Cancel',
-  open: true,
+  onValidate: () => {},
+  onCancel: () => {},
 }
 
 export default Confirm
-
-// // Usage in API
-
-// import { confirm, Confirm } from 'fyndiq-component-modal'
-
-// const a = async confirmButton() {
-//   const validated = await confirm(
-//     <Confirm type="warning" icon={<Warning />} title="Are you sure?" />
-//   )
-// }

--- a/packages/fyndiq-component-modal/src/index.js
+++ b/packages/fyndiq-component-modal/src/index.js
@@ -1,5 +1,9 @@
+import confirm from './confirm-promise'
+import Confirm from './confirm'
+import ConfirmWrapper from './confirm-wrapper'
+
 import Modal from './modal'
 import ModalButton from './modal-button'
 
 export default Modal
-export { ModalButton }
+export { confirm, Confirm, ConfirmWrapper, ModalButton }

--- a/packages/fyndiq-ui-test/stories/component-modal.js
+++ b/packages/fyndiq-ui-test/stories/component-modal.js
@@ -1,7 +1,13 @@
 import React from 'react'
-import { storiesOf } from '@storybook/react'
+import { storiesOf, action } from '@storybook/react'
 import Button from 'fyndiq-component-button'
-import Modal, { ModalButton } from 'fyndiq-component-modal'
+import Modal, {
+  ModalButton,
+  confirm,
+  Confirm,
+  ConfirmWrapper,
+} from 'fyndiq-component-modal'
+import { Warning } from 'fyndiq-icons'
 
 import './component-modal.css'
 
@@ -41,4 +47,29 @@ storiesOf('Modal', module)
         )}
       </Modal>
     </ModalButton>
+  ))
+  .addWithInfo('confirm dialog', () => (
+    <React.Fragment>
+      <ConfirmWrapper />
+      <Button
+        onClick={async () => {
+          const validate = await confirm(
+            <Confirm
+              type="warning"
+              icon={<Warning />}
+              title="Do you really want to delete that thing?"
+              message="If you delete it, there is no way back"
+              validateButton="Delete"
+            />,
+          )
+          if (validate) {
+            action('validated')()
+          } else {
+            action('not validated')()
+          }
+        }}
+      >
+        Delete something
+      </Button>
+    </React.Fragment>
   ))


### PR DESCRIPTION
## Overview

This pull-request adds a `Confirm` component, as well as a `confirm` utility function to easily create interactive confirm dialogs.

Checkout the [doc](https://github.com/fyndiq/fyndiq-ui/blob/b2f93f0d4f9f8b0636bf32573590635760d85d79/packages/fyndiq-component-modal/README.md#confirm) to understand the new API

