### PR TITLE
Add fixedHeight prop to Price component

### DIFF
--- a/packages/fyndiq-component-article/article-price.css
+++ b/packages/fyndiq-component-article/article-price.css
@@ -3,16 +3,15 @@
 .price {
   display: inline-block;
   white-space: nowrap;
+  line-height: 1.2;
 }
 
 .currentPrice {
   color: var(--color-red);
-  display: block;
   font-weight: bold;
 }
 
 .oldPrice {
-  display: block;
   color: var(--color-lightgrey);
   text-decoration: line-through;
   font-weight: 300;
@@ -25,5 +24,15 @@
 
   & .oldPrice {
     font-size: 11px;
+  }
+}
+
+.fixedHeight {
+  & .currentPrice {
+    height: 1.2em;
+  }
+
+  & .oldPrice {
+    height: 1.2em;
   }
 }

--- a/packages/fyndiq-component-article/src/__snapshots__/price.test.js.snap
+++ b/packages/fyndiq-component-article/src/__snapshots__/price.test.js.snap
@@ -5,15 +5,19 @@ exports[`Article Price should have a default structure 1`] = `
   className="
         price
         emphasize
+        false
       "
 >
-  <span
+  <div
     className="currentPrice"
   >
     123kr
-  </span>
-  <span
+     
+  </div>
+  <div
     className="oldPrice"
-  />
+  >
+     
+  </div>
 </span>
 `;

--- a/packages/fyndiq-component-article/src/price.js
+++ b/packages/fyndiq-component-article/src/price.js
@@ -2,16 +2,17 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styles from '../article-price.css'
 
-const Price = ({ children, oldPrice, emphasize }) =>
-  children && (
+const Price = ({ children, oldPrice, emphasize, fixedHeight }) =>
+  (children || fixedHeight) && (
     <span
       className={`
         ${styles.price}
         ${emphasize && styles.emphasize}
+        ${fixedHeight && styles.fixedHeight}
       `}
     >
-      <span className={styles.currentPrice}>{children}</span>
-      <span className={styles.oldPrice}>{oldPrice}</span>
+      <div className={styles.currentPrice}>{children} </div>
+      <div className={styles.oldPrice}>{oldPrice} </div>
     </span>
   )
 
@@ -19,12 +20,14 @@ Price.propTypes = {
   children: PropTypes.string,
   oldPrice: PropTypes.string,
   emphasize: PropTypes.bool,
+  fixedHeight: PropTypes.bool,
 }
 
 Price.defaultProps = {
   children: null,
   oldPrice: null,
   emphasize: true,
+  fixedHeight: false,
 }
 
 export default Price

--- a/packages/fyndiq-component-button/styles.css
+++ b/packages/fyndiq-component-button/styles.css
@@ -48,7 +48,7 @@
 .type-blue {
   background-color: var(--color-white);
   color: var(--color-blue);
-  border-color: var(--color-border);
+  border-color: var(--color-blue);
 
   &.interactive:hover,
   &.interactive:focus {

--- a/packages/fyndiq-component-checkbox/src/__snapshots__/index.test.js.snap
+++ b/packages/fyndiq-component-checkbox/src/__snapshots__/index.test.js.snap
@@ -20,7 +20,7 @@ exports[`fyndiq-component-checkbox should be invoquable without parameters 1`] =
   />
   <Checkmark
     className="checkmark"
-    color="#7E7E7E"
+    color="#9B9B9B"
   />
 </label>
 `;
@@ -29,7 +29,7 @@ exports[`fyndiq-component-checkbox should be programatically checkable 1`] = `
 <Checkbox
   checked={true}
   className=""
-  color="#7E7E7E"
+  color="#9B9B9B"
   disabled={false}
   frame={false}
   indeterminate={false}
@@ -54,7 +54,7 @@ exports[`fyndiq-component-checkbox should be programatically checkable 1`] = `
     />
     <Checkmark
       className="checkmark"
-      color="#7E7E7E"
+      color="#9B9B9B"
     >
       <SvgWrapper
         className="checkmark"
@@ -69,7 +69,7 @@ exports[`fyndiq-component-checkbox should be programatically checkable 1`] = `
         >
           <path
             d="M16.8 42c-.4 0-1-.2-1.2-.5l-14-14.2c-.8-.7-.8-1.8 0-2.5.6-.7 1.7-.7 2.4 0l12.8 13 29-29c.7-.7 1.8-.7 2.5 0s.7 1.8 0 2.5L18 41.5c-.2.3-.7.5-1.2.5z"
-            fill="#7E7E7E"
+            fill="#9B9B9B"
             stroke="none"
           />
         </svg>
@@ -99,7 +99,7 @@ exports[`fyndiq-component-checkbox should have prop checked 1`] = `
   />
   <Checkmark
     className="checkmark"
-    color="#7E7E7E"
+    color="#9B9B9B"
   />
 </label>
 `;
@@ -149,7 +149,7 @@ exports[`fyndiq-component-checkbox should have prop disabled 1`] = `
   />
   <Checkmark
     className="checkmark"
-    color="#7E7E7E"
+    color="#9B9B9B"
   />
 </label>
 `;
@@ -174,7 +174,7 @@ exports[`fyndiq-component-checkbox should have prop onToggle 1`] = `
   />
   <Checkmark
     className="checkmark"
-    color="#7E7E7E"
+    color="#9B9B9B"
   />
 </label>
 `;
@@ -199,7 +199,7 @@ exports[`fyndiq-component-checkbox should update its state when clicked on 1`] =
   />
   <Checkmark
     className="checkmark"
-    color="#7E7E7E"
+    color="#9B9B9B"
   />
 </label>
 `;
@@ -224,7 +224,7 @@ exports[`fyndiq-component-checkbox should update its state when clicked on 2`] =
   />
   <Checkmark
     className="checkmark"
-    color="#7E7E7E"
+    color="#9B9B9B"
   />
 </label>
 `;

--- a/packages/fyndiq-styles-colors/colors.css
+++ b/packages/fyndiq-styles-colors/colors.css
@@ -5,7 +5,7 @@
   /* Grey levels */
   --color-black: #3B4257;
   --color-darkgrey: #666;
-  --color-lightgrey: #7E7E7E;
+  --color-lightgrey: #9B9B9B;
   --color-palegrey: #FAFAFC;
   --color-white: #FFF;
 

--- a/packages/fyndiq-styles-colors/src/index.js
+++ b/packages/fyndiq-styles-colors/src/index.js
@@ -5,7 +5,7 @@ export default {
   /* Grey levels */
   black: '#3B4257',
   darkgrey: '#666',
-  lightgrey: '#7E7E7E',
+  lightgrey: '#9B9B9B',
   palegrey: '#FAFAFC',
   white: '#FFF',
 


### PR DESCRIPTION
## Overview

This PR adds a `fixedHeight` prop to the Price Component, so that it always take the same height wether or not the `oldPrice` is present.

This is useful for lists, so that the product card is always the same size.

<img width="388" alt="screen shot 2018-01-26 at 10 19 59" src="https://user-images.githubusercontent.com/1416801/35433107-82bc929c-0282-11e8-8707-de844021965c.png">

### Other changes

<img width="92" align="right" alt="screen shot 2018-01-26 at 10 31 24" src="https://user-images.githubusercontent.com/1416801/35433550-20c18d66-0284-11e8-9ec2-8595cad19c85.png">

- The `color-lightgrey` has been made lighter, according to design
- The price component has a slightly smaller `line-height`
- Change design of the "secondary" button (new style on the right)