### PR TITLE
Invisible input fix

### DIFF
--- a/packages/fyndiq-component-input/input.css
+++ b/packages/fyndiq-component-input/input.css
@@ -8,6 +8,7 @@
   border-radius: 2px;
   font-size: 15px;
   line-height: 48px;
+  box-shadow: 0 0 5px 0 color(var(--color-black) a(10%));
   outline: 0;
   appearance: none;
 

--- a/packages/fyndiq-component-input/package.json
+++ b/packages/fyndiq-component-input/package.json
@@ -14,7 +14,8 @@
     "fyndiq-component-dropdown": "^2.8.2",
     "fyndiq-icons": "^2.8.0",
     "fyndiq-styles-colors": "^2.3.0",
-    "lodash.debounce": "4.0.8"
+    "lodash.debounce": "4.0.8",
+    "react-input-autosize": "^2.2.1"
   },
   "peerDependencies": {
     "css-loader": "^0.28.7",

--- a/packages/fyndiq-component-input/search.css
+++ b/packages/fyndiq-component-input/search.css
@@ -35,6 +35,7 @@
 .input {
   border: none;
   padding: 0;
+  box-shadow: none;
   transition: .15s ease-out;
   background: transparent;
   outline: 0;

--- a/packages/fyndiq-component-input/src/__snapshots__/invisible.test.js.snap
+++ b/packages/fyndiq-component-input/src/__snapshots__/invisible.test.js.snap
@@ -16,6 +16,7 @@ exports[`fyndiq-component-input Invisible should have the proper structure 1`] =
           "
     onChange={[Function]}
     onKeyDown={[Function]}
+    value=""
   />
   <button
     className="invisibleSubmit"

--- a/packages/fyndiq-component-input/src/index.js
+++ b/packages/fyndiq-component-input/src/index.js
@@ -1,7 +1,8 @@
 import Input from './input'
 import Presets from './presets'
 import InvisibleInput from './invisible'
+import InvisibleNoFormInput from './invisible-no-form'
 import SearchInput from './search'
 
 export default Input
-export { Presets, InvisibleInput, SearchInput }
+export { Presets, InvisibleInput, InvisibleNoFormInput, SearchInput }

--- a/packages/fyndiq-component-input/src/invisible-no-form.js
+++ b/packages/fyndiq-component-input/src/invisible-no-form.js
@@ -11,6 +11,7 @@ const InvisibleNoFormInput = ({ onChange, value, ...props }) => (
       ${!value && styles.invisibleInputEmpty}
     `}
     onChange={e => onChange(e.target.value)}
+    extraWidth={40}
     value={value}
     {...props}
   />

--- a/packages/fyndiq-component-input/src/invisible-no-form.js
+++ b/packages/fyndiq-component-input/src/invisible-no-form.js
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import AutosizeInput from 'react-input-autosize'
+
+import styles from '../input.css'
+
+const InvisibleNoFormInput = ({ onChange, value, ...props }) => (
+  <AutosizeInput
+    inputClassName={`
+      ${styles.invisibleInput}
+      ${!value && styles.invisibleInputEmpty}
+    `}
+    onChange={e => onChange(e.target.value)}
+    value={value}
+    {...props}
+  />
+)
+
+InvisibleNoFormInput.propTypes = {
+  onChange: PropTypes.func,
+  value: PropTypes.string,
+}
+
+InvisibleNoFormInput.defaultProps = {
+  onChange: () => {},
+  value: '',
+}
+
+export default InvisibleNoFormInput

--- a/packages/fyndiq-component-input/src/invisible.js
+++ b/packages/fyndiq-component-input/src/invisible.js
@@ -13,7 +13,7 @@ class InvisibleInput extends React.Component {
 
   static defaultProps = {
     onChange: () => {},
-    value: undefined,
+    value: '',
     className: '',
   }
 


### PR DESCRIPTION
## Overview

This PR intends to fix some issues with invisible input.

It adds a new component, `InvisibleNoFormInput` which is an invisible input but without the form-like feeling (it means that there is no validate button anymore, and you don't need to press "Enter" to reflect your changes)

It also fixes a 🐛 bug with `InvisibleInput` switching from uncontrolled to controlled mode.