### PR TITLE
Fix server-side rendering

### DIFF
--- a/packages/fyndiq-component-article/src/images.js
+++ b/packages/fyndiq-component-article/src/images.js
@@ -30,6 +30,12 @@ class ArticleImages extends React.Component {
     document.addEventListener('keyup', this.handleKeyPress)
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.images !== this.props.images) {
+      this.setState({ imgId: 0 })
+    }
+  }
+
   componentWillUnmount() {
     document.removeEventListener('keyup', this.handleKeyPress)
   }

--- a/packages/fyndiq-component-dropdown/src/index.js
+++ b/packages/fyndiq-component-dropdown/src/index.js
@@ -72,9 +72,12 @@ class Dropdown extends React.Component {
   }
 
   componentWillMount() {
-    document.addEventListener('click', this.handleDocumentClick)
-    document.addEventListener('touchend', this.handleDocumentClick)
-    document.addEventListener('keypress', this.handleKeypress, true)
+    // The guard is here in order to handle server-side rendering
+    if (global.document && document.addEventListener) {
+      document.addEventListener('click', this.handleDocumentClick)
+      document.addEventListener('touchend', this.handleDocumentClick)
+      document.addEventListener('keypress', this.handleKeypress, true)
+    }
   }
 
   componentDidMount() {
@@ -93,9 +96,11 @@ class Dropdown extends React.Component {
   }
 
   componentWillUnmount() {
-    document.removeEventListener('click', this.handleDocumentClick)
-    document.removeEventListener('touchend', this.handleDocumentClick)
-    document.removeEventListener('keypress', this.handleKeypress, true)
+    if (global.document && document.addEventListener) {
+      document.removeEventListener('click', this.handleDocumentClick)
+      document.removeEventListener('touchend', this.handleDocumentClick)
+      document.removeEventListener('keypress', this.handleKeypress, true)
+    }
   }
 
   onButtonClick() {

--- a/packages/fyndiq-component-dropdown/src/index.js
+++ b/packages/fyndiq-component-dropdown/src/index.js
@@ -84,9 +84,18 @@ class Dropdown extends React.Component {
     this.updateDropdownPosition()
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (nextProps.opened !== this.props.opened) {
+      this.setState({ opened: nextProps.opened })
+    }
+  }
+
   componentDidUpdate(prevProps, prevState) {
     // Call handlers onOpen and onClose if open has changed
-    if (prevState.opened !== this.state.opened) {
+    if (
+      prevState.opened !== this.state.opened &&
+      this.props.opened === prevProps.opened
+    ) {
       if (this.state.opened) {
         this.props.onOpen()
       } else {
@@ -143,6 +152,10 @@ class Dropdown extends React.Component {
   }
 
   updateDropdownPosition() {
+    if (!this.buttonNode || !this.buttonNode.getBoundingClientRect) {
+      return
+    }
+
     const buttonSize = this.buttonNode.getBoundingClientRect()
     const { position, margin } = this.props
     let left = this.buttonNode.offsetLeft

--- a/packages/fyndiq-component-dropdown/src/index.js
+++ b/packages/fyndiq-component-dropdown/src/index.js
@@ -17,7 +17,8 @@ import styles from '../styles.css'
 const isSameType = (element, component) =>
   React.isValidElement(element) &&
   (element.type === component ||
-    (element.type && element.type.displayName === component.name))
+    (element.type && element.type.displayName === component.name) ||
+    (element.type && element.type.name === component.name))
 
 class Dropdown extends React.Component {
   static propTypes = {

--- a/packages/fyndiq-component-dropdown/src/index.test.js
+++ b/packages/fyndiq-component-dropdown/src/index.test.js
@@ -251,9 +251,7 @@ describe('fyndiq-component-dropdown', () => {
       },
     )
     component.setProps({ opened: true })
-    component.update()
     component.setProps({ opened: false })
-    component.update()
     expect(spy).not.toHaveBeenCalled()
   })
 

--- a/packages/fyndiq-component-dropdown/src/index.test.js
+++ b/packages/fyndiq-component-dropdown/src/index.test.js
@@ -230,6 +230,33 @@ describe('fyndiq-component-dropdown', () => {
     expect(spy).toHaveBeenCalled()
   })
 
+  it('should be controllable', () => {
+    const component = shallow(<Dropdown button="button">Content</Dropdown>, {
+      disableLifecycleMethods: true,
+    })
+    component.setProps({ opened: true })
+    expect(component.find('.dropdownWrapper').exists()).toBe(true)
+    component.setProps({ opened: false })
+    expect(component.find('.dropdownWrapper').exists()).toBe(false)
+  })
+
+  it('should not call handlers when control toggled', () => {
+    const spy = jest.fn()
+    const component = shallow(
+      <Dropdown button="button" onOpen={spy} onClose={spy}>
+        Content
+      </Dropdown>,
+      {
+        disableLifecycleMethods: false,
+      },
+    )
+    component.setProps({ opened: true })
+    component.update()
+    component.setProps({ opened: false })
+    component.update()
+    expect(spy).not.toHaveBeenCalled()
+  })
+
   describe('disabled prop', () => {
     it('should open when clicking on the button', () => {
       const component = shallow(

--- a/packages/fyndiq-component-dropdown/styles.css
+++ b/packages/fyndiq-component-dropdown/styles.css
@@ -43,7 +43,7 @@
 @keyframes bl {
   from {
     opacity: 0;
-    transform: translate(0, -var(--translateFactor)) scale(var(--scaleFactor));
+    transform: translate(0, calc(0 - var(--translateFactor))) scale(var(--scaleFactor));
   }
 
   to {
@@ -60,7 +60,7 @@
 @keyframes bc {
   from {
     opacity: 0;
-    transform: translate(-50%, -var(--translateFactor)) scale(var(--scaleFactor));
+    transform: translate(-50%, calc(0 - var(--translateFactor))) scale(var(--scaleFactor));
   }
 
   to {
@@ -77,7 +77,7 @@
 @keyframes br {
   from {
     opacity: 0;
-    transform: translate(-100%, -var(--translateFactor)) scale(var(--scaleFactor));
+    transform: translate(-100%, calc(0 - var(--translateFactor))) scale(var(--scaleFactor));
   }
 
   to {

--- a/packages/fyndiq-component-message/README.md
+++ b/packages/fyndiq-component-message/README.md
@@ -45,7 +45,7 @@ class MyComponent extends React.Component {
 }
 
 // Customize the message
-import { Error, Warning } from 'fyndiq-icons
+import { Error, Warning } from 'fyndiq-icons'
 addMessage(
   <Message
     type="error"

--- a/packages/fyndiq-component-message/src/message-portal.js
+++ b/packages/fyndiq-component-message/src/message-portal.js
@@ -17,6 +17,8 @@ class MessagePortal extends React.Component {
   }
 
   componentWillMount() {
+    if (!global.document) return
+
     // Create portal element if it doesn't exist
     if (!document.getElementById(this.props.portalId)) {
       const portalDiv = document.createElement('div')
@@ -26,6 +28,10 @@ class MessagePortal extends React.Component {
   }
 
   render() {
+    if (!global.document) {
+      return this.props.children
+    }
+
     return ReactDOM.createPortal(
       this.props.children,
       document.getElementById(this.props.portalId),

--- a/packages/fyndiq-component-message/src/message-portal.js
+++ b/packages/fyndiq-component-message/src/message-portal.js
@@ -17,8 +17,6 @@ class MessagePortal extends React.Component {
   }
 
   componentWillMount() {
-    if (!global.document) return
-
     // Create portal element if it doesn't exist
     if (!document.getElementById(this.props.portalId)) {
       const portalDiv = document.createElement('div')
@@ -28,10 +26,6 @@ class MessagePortal extends React.Component {
   }
 
   render() {
-    if (!global.document) {
-      return this.props.children
-    }
-
     return ReactDOM.createPortal(
       this.props.children,
       document.getElementById(this.props.portalId),

--- a/packages/fyndiq-component-message/src/message-wrapper.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.js
@@ -37,7 +37,9 @@ class MessageWrapper extends React.Component {
   }
 
   componentWillUnmount() {
-    MessageWrapper.instance = null
+    if (MessageWrapper.instance === this) {
+      MessageWrapper.instance = null
+    }
   }
 
   addMessage(message) {

--- a/packages/fyndiq-component-message/src/message-wrapper.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.js
@@ -24,6 +24,11 @@ class MessageWrapper extends React.Component {
   }
 
   componentWillMount() {
+    // Server-side rendering is not supported
+    if (!global.document) {
+      return
+    }
+
     if (MessageWrapper.instance != null) {
       console.warn('MessageWrapper already had an instance')
     }

--- a/packages/fyndiq-component-message/src/message-wrapper.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.js
@@ -59,6 +59,8 @@ class MessageWrapper extends React.Component {
   }
 
   render() {
+    if (this.state.messages.length === 0) return null
+
     return (
       <MessagePortal>
         <div className={styles.wrapper}>

--- a/packages/fyndiq-component-message/src/message-wrapper.test.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.test.js
@@ -21,6 +21,20 @@ describe('fyndiq-component-message MessageWrapper', () => {
     expect(console.warn).toHaveBeenCalled()
   })
 
+  it('should forget about the running instance if it is unmounted', () => {
+    const component = shallow(<Wrapper />)
+    component.unmount()
+    expect(Wrapper.instance).toBe(null)
+  })
+
+  it('should not erase the running instance if another one gets removed', () => {
+    const instance1 = shallow(<Wrapper />)
+    // Mount another instance that will be tracked by Wrapper.
+    shallow(<Wrapper />)
+    instance1.unmount()
+    expect(Wrapper.instance).not.toBe(null)
+  })
+
   it('should remove messages internally', () => {
     const component = shallow(<Wrapper />)
     Wrapper.addMessage(<Message>New message</Message>)

--- a/packages/fyndiq-component-message/src/message-wrapper.test.js
+++ b/packages/fyndiq-component-message/src/message-wrapper.test.js
@@ -30,6 +30,10 @@ describe('fyndiq-component-message MessageWrapper', () => {
     expect(component.find(Message).exists()).toBe(false)
   })
 
+  it('should not render anything if there is no message', () => {
+    expect(shallow(<Wrapper />).isEmptyRender()).toBe(true)
+  })
+
   describe('static addMessage', () => {
     it('should have a static addMessage function', () => {
       const component = shallow(<Wrapper />)

--- a/packages/fyndiq-component-modal/src/__snapshots__/modal-button.test.js.snap
+++ b/packages/fyndiq-component-modal/src/__snapshots__/modal-button.test.js.snap
@@ -22,7 +22,7 @@ exports[`ModalButton Component should display a button by default 1`] = `
     onClose={[Function]}
     open={false}
     overlayClassName=""
-    portalId="fyndiq-modal"
+    portalId="fyndiq-modal-portal"
     wrapperClassName=""
   >
     Content
@@ -37,7 +37,7 @@ exports[`ModalButton Component should handle Modal children as a prop 1`] = `
   onClose={[Function]}
   open={false}
   overlayClassName="overlayClassName"
-  portalId="fyndiq-modal"
+  portalId="fyndiq-modal-portal"
   wrapperClassName=""
 >
   Content

--- a/packages/fyndiq-component-modal/src/__snapshots__/modal.test.js.snap
+++ b/packages/fyndiq-component-modal/src/__snapshots__/modal.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Modal Component should be displayed correctly if opened 1`] = `
 <ModalPortal
   bodyLock={true}
-  portalId="fyndiq-modal"
+  portalId="fyndiq-modal-portal"
 >
   <div
     className="overlay "
@@ -28,7 +28,7 @@ exports[`Modal Component should be displayed correctly if opened 1`] = `
 exports[`Modal Component should have custom classes for different elements 1`] = `
 <ModalPortal
   bodyLock={true}
-  portalId="fyndiq-modal"
+  portalId="fyndiq-modal-portal"
 >
   <div
     className="overlay overlayClassName"

--- a/packages/fyndiq-component-modal/src/confirm-wrapper.js
+++ b/packages/fyndiq-component-modal/src/confirm-wrapper.js
@@ -23,6 +23,11 @@ class ConfirmWrapper extends React.Component {
   }
 
   componentWillMount() {
+    // Server-side rendering is not supported
+    if (!global.document) {
+      return
+    }
+
     if (ConfirmWrapper.instance != null) {
       console.warn('ConfirmWrapper already had an instance running')
     }

--- a/packages/fyndiq-component-modal/src/confirm-wrapper.js
+++ b/packages/fyndiq-component-modal/src/confirm-wrapper.js
@@ -36,7 +36,9 @@ class ConfirmWrapper extends React.Component {
   }
 
   componentWillUnmount() {
-    ConfirmWrapper.instance = null
+    if (ConfirmWrapper.instance === this) {
+      ConfirmWrapper.instance = null
+    }
   }
 
   onCancel() {

--- a/packages/fyndiq-component-modal/src/modal-button.js
+++ b/packages/fyndiq-component-modal/src/modal-button.js
@@ -7,7 +7,8 @@ import Modal from './modal'
 const isSameType = (element, component) =>
   React.isValidElement(element) &&
   (element.type === component ||
-    (element.type && element.type.displayName === component.name))
+    (element.type && element.type.displayName === component.name) ||
+    (element.type && element.type.name === component.name))
 
 // Proptype checker: checks that the element is of a specific Component type
 // FIXME: this declaration should be in its own package, like fyndiq-utils

--- a/packages/fyndiq-component-modal/src/modal-portal.js
+++ b/packages/fyndiq-component-modal/src/modal-portal.js
@@ -18,7 +18,7 @@ class ModalPortal extends React.Component {
 
   static defaultProps = {
     children: null,
-    portalId: 'fyndiq-portal',
+    portalId: 'fyndiq-modal-portal',
     bodyLock: false,
   }
 

--- a/packages/fyndiq-component-modal/src/modal.js
+++ b/packages/fyndiq-component-modal/src/modal.js
@@ -18,7 +18,7 @@ class Modal extends React.Component {
   static defaultProps = {
     open: false,
     children: null,
-    portalId: 'fyndiq-modal',
+    portalId: 'fyndiq-modal-portal',
     overlayClassName: '',
     wrapperClassName: '',
     closeClassName: '',
@@ -33,12 +33,16 @@ class Modal extends React.Component {
   }
 
   componentWillMount() {
-    // Register key events
-    document.addEventListener('keypress', this.handleKeyPress)
+    if (global.document && document.addEventListener) {
+      // Register key events
+      document.addEventListener('keypress', this.handleKeyPress)
+    }
   }
 
   componentWillUnmount() {
-    document.removeEventListener('keypress', this.handleKeyPress)
+    if (global.document && document.addEventListener) {
+      document.removeEventListener('keypress', this.handleKeyPress)
+    }
   }
 
   getChildren() {

--- a/packages/fyndiq-icons/src/star.js
+++ b/packages/fyndiq-icons/src/star.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import SvgWrapper from './svg-wrapper'
 
 const Star = ({ className, color, colorEmpty, full }) => {
-  const starId = `${Math.random()}`
+  const starId = `star-${full}`
   return (
     <SvgWrapper className={className} viewBox="-5 -5 60 60">
       <defs>


### PR DESCRIPTION
# 👓 Overview

Some components expect the DOM to be present in their lifecycles, we need to add some guards to make sure that the component is renderable in an environment where `document` is not defined.

## 🔧 List of changes

- **`fyndiq-component-dropdown`** 🐛 Fix some bugs
- **`fyndiq-component-modal`** 🐛 Fix some bugs